### PR TITLE
[#78] 로그인 기능 구현

### DIFF
--- a/frontend/src/components/common/HeaderComponent.vue
+++ b/frontend/src/components/common/HeaderComponent.vue
@@ -1,21 +1,30 @@
 <template>
     <div>
         <div class="css-t79vuj e15sbxqa2">
-            <div class="css-1xfyvd1 eo7pjfk4">
-                <a class="css-oyffzd eo7pjfk2 top-menu-link"><router-link to="/auth/login">로그인</router-link></a>
+            <div v-show="!userStore.isLogined" class="css-1xfyvd1 eo7pjfk4">
+                <router-link to="/auth/login" class="css-oyffzd eo7pjfk2 top-menu-link">로그인</router-link>
                 <div class="css-1qgm48u eo7pjfk0">
                 </div>
-                <a class="css-xygizb eo7pjfk2 top-menu-link"><RouterLink to="/auth/user/signup">일반회원가입</RouterLink></a>
+                <RouterLink to="/auth/user/signup" class="css-xygizb eo7pjfk2 top-menu-link">일반회원가입</RouterLink>
                 <div class="css-1qgm48u eo7pjfk0">
                 </div>
-                <a class="css-xygizb eo7pjfk2 top-menu-link"><RouterLink to="/auth/company/signup">업체회원가입</RouterLink></a>
+                <RouterLink to="/auth/company/signup" class="css-xygizb eo7pjfk2 top-menu-link">업체회원가입</RouterLink>
+            </div>
+
+            <div v-show="userStore.isLogined" class="css-1xfyvd1 eo7pjfk4">
+                <span class="css-oyffzd eo7pjfk2 top-menu-link" @click="logout">로그아웃</span>
+                <div class="css-1qgm48u eo7pjfk0">
+                </div>
+                <RouterLink to="/mypage" class="css-xygizb eo7pjfk2 top-menu-link">마이페이지</RouterLink>
                 
                 
             </div>
+
+
             <div class="css-r7wmjj e15sbxqa3">
                 <div class="css-boc80u ekdqe1a1"><img
                         src="https://github.com/user-attachments/assets/97e43864-23d5-4f0d-844d-8a8e20aeade2"
-                        alt="딜리버리 로고" class="css-17mnrrx e1s3pt0j0 logo" @click="routeToMain"><button
+                        alt="딜리버리 로고" class="css-17mnrrx e1s3pt0j0 logo" @click="routeTo('/')"><button
                         class="active css-mxd3pm ekdqe1a0"><router-link
                             to="/">Dealivery</router-link></button><button
                         class=" css-mxd3pm ekdqe1a0">Company</button></div>
@@ -52,14 +61,21 @@
 </template>
 
 <script>
+import { useUserStore } from '@/stores/useUserStore';
+import { mapStores } from 'pinia';
 export default {
     name: 'HeaderComponent',
-    props: {
-        msg: String
+    computed: {
+        ...mapStores(useUserStore)
     },
     methods:{
-        routeToMain(){
-            this.$router.push("/");
+        routeTo(path){
+            this.$router.push(path);
+        },
+        logout(){
+            this.userStore.isLogined = false;
+            this.userStore.roles = [];
+            this.routeTo('/');
         }
     }
 }

--- a/frontend/src/components/user/LoginComponent.vue
+++ b/frontend/src/components/user/LoginComponent.vue
@@ -4,33 +4,34 @@
         <div class="css-1axolzg etkckst0">
             <div class="css-1izr46f e1fu5st01">
                 <button type="button"
-                :class="{'active': userType === 'user', 'inactive': userType !== 'user'}"
+                :class="{'active': type === 'user', 'inactive': type !== 'user'}"
                  class="e1fu5st00" @click="setUserType('user')">일반 회원</button>
                 <button type="button"
-                :class="{'active': userType === 'company', 'inactive': userType !== 'company'}"
+                :class="{'active': type === 'company', 'inactive': type !== 'company'}"
                 class="inactive e1fu5st00" @click="setUserType('company')">업체 회원</button>
             </div>
-            <form class="formbox">
                 <div class="css-46b038 e18ap6t76 formbox">
-                    <div class="css-1accgqb e1uzxhvi6">
-                        <div class="css-176lya2 e1uzxhvi3"><input data-testid="input-box" name="id"
-                                placeholder="아이디를 입력해주세요" type="text" class="css-u52dqk e1uzxhvi2" value=""></div>
-                    </div>
-                    <div class="css-1accgqb e1uzxhvi6">
-                        <div class="css-176lya2 e1uzxhvi3">
-                            <input data-testid="input-box" name="password" placeholder="비밀번호를 입력해주세요" type="password"
-                                autocomplete="off" class="css-u52dqk e1uzxhvi2" value="">
+                    <form class="formbox">
+                        <div class="css-1accgqb e1uzxhvi6">
+                            <div class="css-176lya2 e1uzxhvi3"><input v-model="loginRequest.id" data-testid="input-box" name="id"
+                                    placeholder="아이디를 입력해주세요" type="text" class="css-u52dqk e1uzxhvi2" value="" @keydown.enter="login" maxlength="30"></div>
                         </div>
-                    </div>
+                        <div class="css-1accgqb e1uzxhvi6">
+                            <div class="css-176lya2 e1uzxhvi3">
+                                <input v-model="loginRequest.password" data-testid="input-box" name="password" placeholder="비밀번호를 입력해주세요" type="password"
+                                    autocomplete="off" class="css-u52dqk e1uzxhvi2" value="" @keydown.enter="login" maxlength="30">
+                            </div>
+                        </div>
+                    </form>
                 </div>
                 <div class="css-1vjdduq e18ap6t75 formbox">
-                    <a class="css-i4t6me e18ap6t74"><router-link to="/auth/id/find">아이디 찾기</router-link></a>
+                    <router-link to="/auth/id/find" class="css-i4t6me e18ap6t74">아이디 찾기</router-link>
                     <span class="css-1cgn39v e18ap6t73"></span>
-                    <a class="css-i4t6me e18ap6t74"><router-link to="/auth/pwd/find">비밀번호 찾기</router-link></a>
+                    <router-link to="/auth/pwd/find" class="css-i4t6me e18ap6t74">비밀번호 찾기</router-link>
                 </div>
                 <div class="css-s4i9n2 e18ap6t71 formbox">
-                    <button class="css-qaxuc4 e4nu7ef3" type="submit" height="54" radius="3">
-                        <span class="css-nytqmg e4nu7ef1">로그인</span>
+                    <button class="css-qaxuc4 e4nu7ef3" type="button" height="54" radius="3" @click="login">
+                        <span class="css-nytqmg e4nu7ef1" >로그인</span>
                     </button>
                     
                     <button class="css-hxorrg e4nu7ef3" id="user" @click="routeToSignup('user')" type="button" height="54" radius="3" style="margin-top: 10px;">
@@ -40,19 +41,26 @@
                         <span class="css-nytqmg e4nu7ef1" >업체회원가입</span>
                     </button>
                 </div>
-            </form>
         </div>
     </div>
 
 </template>
 
 <script>
-
+import { useUserStore } from '@/stores/useUserStore';
+import { mapStores } from 'pinia';
 export default {
   name: 'LoginComponent',
   data(){
-    return {userType:'user'}
+    return {type: "user", loginRequest:{
+        id: "",
+        password: ""
+        }
+    }
   },
+  computed: {
+        ...mapStores(useUserStore)
+    },
   methods:{
     routeToSignup(type){
         if(type === 'user'){
@@ -62,7 +70,37 @@ export default {
         }
     },
     setUserType(type){
-      this.userType = type;
+      this.type = type;
+    },
+    login(){
+        if(this.validateForm()){
+            if(this.userStore.login(this.type, this.loginRequest)){
+                this.$router.push('/');
+            }
+        }
+        
+    },
+    validateForm(){
+        const idRegex = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
+
+        if(this.loginRequest.id.length === 0){
+            alert("아이디를 입력해주세요");
+            return false;
+        }
+        if(this.loginRequest.password.length === 0){
+            alert("비밀번호를 입력해주세요");
+            return false;
+        }
+        if(!idRegex.test(this.loginRequest.id)){
+            alert("아이디 형식이 올바르지 않습니다.")
+            return false;
+        }
+        if (this.loginRequest.id.length > 30 || this.loginRequest.password.length > 30){
+            alert("아이디또는 비밀번호는 30자를 초과할 수 없습니다.")
+            return false;
+        }
+
+        return true;
     }
   },
 }

--- a/frontend/src/stores/useUserStore.js
+++ b/frontend/src/stores/useUserStore.js
@@ -1,0 +1,30 @@
+import { defineStore } from "pinia";
+import axios from "axios";
+
+// const backend = "http://localhost:8080/api/login";
+//로그인 성공 요청 mocky url: https://run.mocky.io/v3/cd7370a5-b1be-41a1-b680-4f93dd1a67bc
+
+export const useUserStore = defineStore('user', {
+    state: () => ({
+        isLogined: false ,roles: []
+    }),
+    actions: {
+        async login(type, loginRequest){
+            try{
+                loginRequest.id = loginRequest.id+";"+type;
+                let response = await axios.post("https://run.mocky.io/v3/cd7370a5-b1be-41a1-b680-4f93dd1a67bc",loginRequest, {withCredentials: true});
+                // let response = await axios.post(backend,loginRequest, {withCredentials: true});
+                if (response.status === 200 && response.data.data.isLogin){
+                    this.roles = [response.data.data.role];
+                    this.isLogined = true;
+                    return true;
+                }else{
+                    alert("로그인에 실패했습니다. 아이디 비밀번호를 확인해주세요.");
+                }
+            }catch(error){
+                alert("로그인에 실패했습니다. 아이디 비밀번호를 확인해주세요.");
+            }   
+        }
+    }
+
+});


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> Closes #78 

<br>
 

## 📝 작업 내용

> 전반적인 로그인 기능 구현

- 입력값 유효성 체크
- 로그인 성공 시 메인화면으로 라우팅
- 로그인 성공 시 상단 헤더 메뉴 v-show로 변경처리 (로그아웃 버튼 보이도록)
- 로그인 버튼 클릭시 백엔드 통신
- 정상처리 시 로그인 상태와 권한 세팅
- 로그아웃 버튼 클릭시 로그인 상태 및 권한 초기화 후 메인화면으로 라우팅
- input태그에서 엔터 감지시 로그인버튼 동작

<br>

## **💬 리뷰 요구사항(선택)**

> 위에서 구현한 기능들이 잘 동작하는지 체크 부탁드립니다.
현재는 mocky와 통신이 오래걸려서 상단헤더 교체시간이 오래걸리지만 백엔드에서 테스트결과 딜레이없으니 이부분은 제외해주세요!

### 유효성
- 공백 금지
- 아이디형식 이메일
- 30글자 제한 (아예 태그에서 막음)

### 라우팅 및 버튼
- 엔터키 입력시 로그인버튼 잘 동작하는지
- 정상적인 값 입력후 로그인통신 완료되면 상단헤더가 잘 바뀌는지
- 로그아웃 버튼 클릭시 상단헤더가 잘 바뀌는지
- 상단헤더 마이페이지 클릭시 /mypage로 라우팅 잘 되는지

