### PR TITLE
[#60] 문의 목록 조회 기능 구현

### DIFF
--- a/frontend/src/components/board/BoardDetailNavComponent.vue
+++ b/frontend/src/components/board/BoardDetailNavComponent.vue
@@ -72,7 +72,7 @@
           <tr @click="toggleInquiry(index)" class="css-atz965 e1l5ky7y9">
             <td class="css-1brd6ns e1l5ky7y8">{{ row.title }}</td>
             <td class="css-1pkqelu e1l5ky7y7">{{ maskAuthorName(row.author) }}</td>
-            <td class="css-1pkqelu e1l5ky7y6">{{ row.created_at }}</td>
+            <td class="css-1pkqelu e1l5ky7y6">{{ row.modified_at || row.created_at }}</td>
             <td class="css-bhr3cq e1l5ky7y5">{{ row.answer_status }}</td>
           </tr>
           <tr v-show="expandedInquiryIndex === index" class="css-1mvq381 e61d7mt0">
@@ -100,7 +100,7 @@
                     <div>{{ row.answer_content }}</div>
                   </div>
                 </div>
-                <div class="css-17g9jzg e1gk8zam0">{{ row.answer_created_at }}</div>
+                <div class="css-17g9jzg e1gk8zam0">{{ row.answer_modified_at || row.answer_created_at }}</div>
               </div>
             </td>
           </tr>

--- a/frontend/src/components/board/BoardDetailNavComponent.vue
+++ b/frontend/src/components/board/BoardDetailNavComponent.vue
@@ -86,8 +86,8 @@
                     <span>{{ row.content }}<br></span>
                   </div>
                 </div>
-                <div class="css-1j49yxi e11ufodi1">
-                  <button type="button" @click="openEditModal(index)">수정</button>
+                <div class="css-1j49yxi e11ufodi1" v-if="row.answer_status !== '답변완료'">
+                  <button type=" button" @click="openEditModal(index)">수정</button>
                   <button type="button" class="css-1ankuif e11ufodi0" @click="deleteInquiry(index)">삭제</button>
                 </div>
               </div>

--- a/frontend/src/components/board/BoardDetailNavComponent.vue
+++ b/frontend/src/components/board/BoardDetailNavComponent.vue
@@ -91,7 +91,7 @@
                   <button type="button" class="css-1ankuif e11ufodi0" @click="deleteInquiry(index)">삭제</button>
                 </div>
               </div>
-              <div class=" css-tnubsz e1ptpt003">
+              <div class=" css-tnubsz e1ptpt003" v-if="row.answer_status !== '답변대기'">
                 <div class="css-1n83etr e1ptpt002">
                   <div class="css-m1wgq7 e1ptpt001">
                     <span class="css-1non6l6 ey0f1wv0"></span>

--- a/frontend/src/components/board/BoardDetailNavComponent.vue
+++ b/frontend/src/components/board/BoardDetailNavComponent.vue
@@ -92,7 +92,7 @@
                 </div>
               </div>
               <div class=" css-tnubsz e1ptpt003">
-                <div class="css-1n83etr e1ptpt002">
+                <!-- <div class="css-1n83etr e1ptpt002">
                   <div class="css-m1wgq7 e1ptpt001">
                     <span class="css-1non6l6 ey0f1wv0"></span>
                   </div>
@@ -105,7 +105,7 @@
                     </div>
                   </div>
                 </div>
-                <div class="css-17g9jzg e1gk8zam0">2024.02.07</div>
+                <div class="css-17g9jzg e1gk8zam0">2024.02.07</div> -->
               </div>
             </td>
           </tr>
@@ -209,10 +209,14 @@ export default {
   },
   watch: {
     tableData(newData) {
-      this.localTableData = newData.map(item => ({
-        ...item,
-        content: item.content || '내용이 없습니다.',
-      }));
+      if (Array.isArray(newData)) {
+        this.localTableData = newData.map(item => ({
+          ...item,
+          content: item.content || '내용이 없습니다.',
+        }));
+      } else {
+        console.error("tableData is not an array:", newData);
+      }
     },
   },
   components: {

--- a/frontend/src/components/board/BoardDetailNavComponent.vue
+++ b/frontend/src/components/board/BoardDetailNavComponent.vue
@@ -92,20 +92,15 @@
                 </div>
               </div>
               <div class=" css-tnubsz e1ptpt003">
-                <!-- <div class="css-1n83etr e1ptpt002">
+                <div class="css-1n83etr e1ptpt002">
                   <div class="css-m1wgq7 e1ptpt001">
                     <span class="css-1non6l6 ey0f1wv0"></span>
                   </div>
                   <div class="css-1bv2zte e1ptpt000">
-                    <div>안녕하세요. 고객님 <br><br>바쁘신 와중에 오늘도 컬리를 찾아주셔서 먼저 감사 인사드립니다.<br><br>
-                      문의하신 [[선물세트] 태우한우 1 + 실속 구이 세트 (냉장)]상품의 경우, 수령일을 포함하여 최소 [ 7 ]일 남은 제품을 보내드리고 있다는 점 안내해 드립니다.
-                      <br><br>다만, 고객님께서 수령하신 날짜를 포함하여 [ 7 ]일이나, 혹시라도 이 기준에 부합하지 못하거나 섭취 할 수 없는 상품을 수령 하셨다면 번거로우시겠지만
-                      컬리 고객행복센터를 통해 이상 여부가 확인 가능한 사진과 함께 접수를 부탁드리며, 담당자를 통하여 신속하게 도움 드릴 수 있도록 최선을 다하겠습니다.<br><br>
-                      감사합니다.<br>Better Life for All. Kurly
-                    </div>
+                    <div>{{ row.answer_content }}</div>
                   </div>
                 </div>
-                <div class="css-17g9jzg e1gk8zam0">2024.02.07</div> -->
+                <div class="css-17g9jzg e1gk8zam0">{{ row.answer_created_at }}</div>
               </div>
             </td>
           </tr>

--- a/frontend/src/pages/user/board/BoardDetailPage.vue
+++ b/frontend/src/pages/user/board/BoardDetailPage.vue
@@ -7,7 +7,7 @@
           <BoardDetailThumnailComponent :thumbnails="thumbnails" />
           <BoardDetailProductInfoComponent @submitOrder="submitOrder" />
         </main>
-        <BoardDetailNavComponent :tableData="tableData" />
+        <BoardDetailNavComponent :tableData="qnaStore.inquiries" />
       </div>
     </div>
   </div>
@@ -22,10 +22,11 @@ import BoardDetailProductInfoComponent from "@/components/board/BoardDetailProdu
 import BoardDetailNavComponent from "@/components/board/BoardDetailNavComponent.vue";
 
 import { useOrderStore } from "@/stores/useOrderStore";
+import { useQnaStore } from "@/stores/useQnaStore";
 import { mapStores } from "pinia";
 
 export default {
-  name: "OrdersPage",
+  name: "BoardDetailPage",
   components: {
     HeaderComponent,
     FooterComponent,
@@ -34,11 +35,15 @@ export default {
     BoardDetailNavComponent,
   },
   computed: {
-    ...mapStores(useOrderStore),
+    ...mapStores(useOrderStore, useQnaStore),
+  },
+  async mounted() {
+    // 페이지가 로드될 때 fetchInquiries를 호출
+    await this.qnaStore.fetchInquiries();
   },
   data() {
     return {
-      activeTab: "description", // 초기에는 '상품설명' 탭이 활성화됨
+      activeTab: "description",
       thumbnails: [
         {
           src: "https://product-image.kurly.com/hdims/resize/%5E%3E720x%3E936/cropcenter/720x936/quality/85/src/product/image/c0599d4f-d892-4d43-a22d-277459e929bd.jpg",
@@ -47,22 +52,7 @@ export default {
           src: "https://pbs.twimg.com/media/EE0R8XcU0AAlbth.jpg",
         },
       ],
-      tableData: [
-        {
-          title: "배송문의드립니다",
-          content: "지금 주문하면 배송 며칠 정도 걸리나요?",
-          author: "송나경",
-          created_at: "2024.09.03",
-          answer_status: "답변완료",
-        },
-        {
-          title: "상품보관 문의드려요.",
-          content: "냉장보관해야되나요?",
-          author: "심키즈",
-          created_at: "2024.09.04",
-          answer_status: "답변완료",
-        },
-      ],
+
     };
   },
   methods: {
@@ -76,9 +66,11 @@ export default {
         console.log("[ERROR] 주문 생성 실패");
       }
     },
+
   },
 };
 </script>
+
 
 <style scoped>
 /*공통 부분*/

--- a/frontend/src/stores/useQnaStore.js
+++ b/frontend/src/stores/useQnaStore.js
@@ -1,0 +1,30 @@
+import { defineStore } from "pinia";
+import axios from "axios";
+
+export const useQnaStore = defineStore("qna", {
+    state: () => ({
+        inquiries: [], test: "ddddddd"
+    }),
+    actions: {
+        async fetchInquiries() {
+            try {
+                const response = await axios.get(
+                    "https://run.mocky.io/v3/0fe8af94-1b49-48eb-8e57-e443f8d7ad83"
+                );
+                this.inquiries = response.data
+            } catch (error) {
+                console.error("문의 목록을 불러오는 중 오류 발생:", error);
+            }
+        },
+        addInquiry(newInquiry) {
+            newInquiry.created_at = new Date().toISOString().split("T")[0];
+            this.inquiries.push(newInquiry);
+        },
+        updateInquiry(index, updatedInquiry) {
+            this.inquiries[index] = { ...this.inquiries[index], ...updatedInquiry };
+        },
+        deleteInquiry(index) {
+            this.inquiries.splice(index, 1);
+        },
+    },
+});

--- a/frontend/src/stores/useQnaStore.js
+++ b/frontend/src/stores/useQnaStore.js
@@ -10,7 +10,8 @@ export const useQnaStore = defineStore("qna", {
             try {
                 const response = await axios.get(
                     //"https://run.mocky.io/v3/0fe8af94-1b49-48eb-8e57-e443f8d7ad83"
-                    "https://run.mocky.io/v3/b10e6691-dcfd-47e9-9bf1-e694933aae72"
+                    //"https://run.mocky.io/v3/b10e6691-dcfd-47e9-9bf1-e694933aae72"
+                    "https://run.mocky.io/v3/21785523-9c59-48aa-81e2-b23c209841e6"
                 );
                 this.inquiries = response.data
             } catch (error) {

--- a/frontend/src/stores/useQnaStore.js
+++ b/frontend/src/stores/useQnaStore.js
@@ -9,7 +9,8 @@ export const useQnaStore = defineStore("qna", {
         async fetchInquiries() {
             try {
                 const response = await axios.get(
-                    "https://run.mocky.io/v3/0fe8af94-1b49-48eb-8e57-e443f8d7ad83"
+                    //"https://run.mocky.io/v3/0fe8af94-1b49-48eb-8e57-e443f8d7ad83"
+                    "https://run.mocky.io/v3/b10e6691-dcfd-47e9-9bf1-e694933aae72"
                 );
                 this.inquiries = response.data
             } catch (error) {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #60 

<br>
 

## 📝 작업 내용

> 문의 목록 조회 시 문의와 답변 데이터를 받아와 화면에 받아온 값을 표시하는 기능 구현

- 문의 작성자, 문의 제목, 문의 내용, 작성일, 답변 여부, 답변 내용, 답변 시간을 받아와 화면에 표시
- 답변이 완료된 문의는 수정/삭제 버튼을 숨김 처리
- 답변대기 상태일 경우 답변 div 부분이 화면에 표시되지 않도록 처리
- 문의나 답변이 수정된 경우, 최초 등록 날짜 대신 수정된 날짜를 화면에 반영

<br>

## **💬 리뷰 요구사항(선택)**

> `"/board/detail/1"` 경로로 이동 -> `문의` 탭 클릭해서 테스트 부탁드립니다!
- [x]  화면에 표시되는 값 중 누락된 속성이 없는지
- [x]  답변이 완료된 문의에서 수정/삭제 버튼이 보이지 않는지 확인
- [x]  답변대기 상태일 경우 답변 표시 부분이 화면에 표시되지 않는지 확인부탁드립니다 :)
