### PR TITLE
[#27] 주문 등록 기능 구현

### DIFF
--- a/backend/src/main/java/org/example/backend/domain/board/product/model/entity/Product.java
+++ b/backend/src/main/java/org/example/backend/domain/board/product/model/entity/Product.java
@@ -30,4 +30,8 @@ public class Product {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name ="productBoard_idx")
 	private ProductBoard productBoard;
+
+    public void decreaseStock(Integer quantity) {
+		this.stock -= quantity;
+    }
 }

--- a/backend/src/main/java/org/example/backend/domain/board/product/repository/ProductRepository.java
+++ b/backend/src/main/java/org/example/backend/domain/board/product/repository/ProductRepository.java
@@ -1,7 +1,14 @@
 package org.example.backend.domain.board.product.repository;
 
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
 import org.example.backend.domain.board.product.model.entity.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM Product p WHERE p.idx = :idx")
+    Optional<Product> findByIdWithLock(Long idx);
 }

--- a/backend/src/main/java/org/example/backend/domain/orders/controller/OrdersController.java
+++ b/backend/src/main/java/org/example/backend/domain/orders/controller/OrdersController.java
@@ -5,6 +5,7 @@ import static org.example.backend.domain.orders.model.dto.OrderDto.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.backend.domain.orders.service.OrderService;
@@ -30,10 +31,11 @@ public class OrdersController {
             requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
                     content = @Content(
                             mediaType = "application/json",
-                            examples = {
-                                    @ExampleObject(value = SwaggerExamples.ORDERS_REGISTER_REQUEST)}
+                            schema = @Schema(implementation = OrderRegisterRequest.class),
+                            examples = @ExampleObject(value = SwaggerExamples.ORDERS_REGISTER_REQUEST)
                     )
-            ))
+            )
+    )
     public ResponseEntity<BaseResponse> registerOrder(/*@AuthenticationPrincipal CustomUserDetails customUserDetails,*/ @RequestBody OrderRegisterRequest order) {
         OrderCreateResponse res = orderService.register(order);
         return ResponseEntity.ok(new BaseResponse(res));

--- a/backend/src/main/java/org/example/backend/domain/orders/controller/OrdersController.java
+++ b/backend/src/main/java/org/example/backend/domain/orders/controller/OrdersController.java
@@ -3,11 +3,15 @@ package org.example.backend.domain.orders.controller;
 import static org.example.backend.domain.orders.model.dto.OrderDto.*;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.backend.domain.orders.service.OrderService;
 
 import org.example.backend.global.common.constants.BaseResponse;
+import org.example.backend.global.common.constants.SwaggerDescription;
+import org.example.backend.global.common.constants.SwaggerExamples;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -22,7 +26,14 @@ public class OrdersController {
     private final OrderService orderService;
 
     @PostMapping("/register")
-    @Operation(summary = "주문 등록 API", description = "주문을 등록하는 API입니다.")
+    @Operation(summary = "주문 등록 API", description = SwaggerDescription.ORDERS_REGISTER_REQUEST,
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(value = SwaggerExamples.ORDERS_REGISTER_REQUEST)}
+                    )
+            ))
     public ResponseEntity<BaseResponse> registerOrder(/*@AuthenticationPrincipal CustomUserDetails customUserDetails,*/ @RequestBody OrderRegisterRequest order) {
         OrderCreateResponse res = orderService.register(order);
         return ResponseEntity.ok(new BaseResponse(res));

--- a/backend/src/main/java/org/example/backend/domain/orders/controller/OrdersController.java
+++ b/backend/src/main/java/org/example/backend/domain/orders/controller/OrdersController.java
@@ -1,0 +1,30 @@
+package org.example.backend.domain.orders.controller;
+
+import static org.example.backend.domain.orders.model.dto.OrderDto.*;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.backend.domain.orders.service.OrderService;
+
+import org.example.backend.global.common.constants.BaseResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/orders")
+@RequiredArgsConstructor
+public class OrdersController {
+    private final OrderService orderService;
+
+    @PostMapping("/register")
+    @Operation(summary = "주문 등록 API", description = "주문을 등록하는 API입니다.")
+    public ResponseEntity<BaseResponse> registerOrder(/*@AuthenticationPrincipal CustomUserDetails customUserDetails,*/ @RequestBody OrderRegisterRequest order) {
+        OrderCreateResponse res = orderService.register(order);
+        return ResponseEntity.ok(new BaseResponse(res));
+    }
+}

--- a/backend/src/main/java/org/example/backend/domain/orders/model/dto/OrderDto.java
+++ b/backend/src/main/java/org/example/backend/domain/orders/model/dto/OrderDto.java
@@ -1,5 +1,7 @@
 package org.example.backend.domain.orders.model.dto;
 
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import lombok.Builder;
 
@@ -13,7 +15,10 @@ public class OrderDto {
     @Builder
     @Getter
     public static class OrderRegisterRequest {
+        @Schema(description = "게시글 idx")
         private Long boardIdx;
+
+        @ArraySchema(arraySchema = @Schema(description = "주문한 상품들"), schema = @Schema(implementation = OrderedProductDto.Request.class))
         private List<OrderedProductDto.Request> orderedProducts;
         public static Orders toEntity(Long boardIdx) {
             return Orders.builder()

--- a/backend/src/main/java/org/example/backend/domain/orders/model/dto/OrderedProductDto.java
+++ b/backend/src/main/java/org/example/backend/domain/orders/model/dto/OrderedProductDto.java
@@ -1,5 +1,6 @@
 package org.example.backend.domain.orders.model.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,8 +14,11 @@ public class OrderedProductDto {
     @Getter
     @AllArgsConstructor
     @NoArgsConstructor
+    @Schema(description = "주문 상품 데이터")
     public static class Request {
+        @Schema(description = "게시글에 등록된 상품 idx", example = "1")
         private Long idx;
+        @Schema(description = "주문한 수량", example = "3")
         private Integer quantity;
         public static OrderedProduct toEntity(Request request, Orders order) {
 

--- a/backend/src/main/java/org/example/backend/domain/orders/repository/OrderedProductRepository.java
+++ b/backend/src/main/java/org/example/backend/domain/orders/repository/OrderedProductRepository.java
@@ -1,0 +1,7 @@
+package org.example.backend.domain.orders.repository;
+
+import org.example.backend.domain.orders.model.entity.OrderedProduct;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderedProductRepository extends JpaRepository<OrderedProduct, Long> {
+}

--- a/backend/src/main/java/org/example/backend/domain/orders/repository/OrdersRepository.java
+++ b/backend/src/main/java/org/example/backend/domain/orders/repository/OrdersRepository.java
@@ -1,0 +1,8 @@
+package org.example.backend.domain.orders.repository;
+
+import org.example.backend.domain.orders.model.entity.Orders;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrdersRepository extends JpaRepository<Orders, Long> {
+
+}

--- a/backend/src/main/java/org/example/backend/domain/orders/service/OrderService.java
+++ b/backend/src/main/java/org/example/backend/domain/orders/service/OrderService.java
@@ -53,7 +53,7 @@ public class OrderService {
     public void validateOrder(OrderRegisterRequest order){
 
         ProductBoard board = productBoardRepository.findById(order.getBoardIdx())
-                .orElseThrow(() -> new InvalidCustomException(ORDER_FAIL_ENVENT_NOT_FOUND));
+                .orElseThrow(() -> new InvalidCustomException(ORDER_FAIL_EVENT_NOT_FOUND));
 
         if (board.getEndedAt().isBefore(LocalDateTime.now())) {
             throw new InvalidCustomException(ORDER_FAIL_EXPIRED_EVENT); // 이벤트가 끝났을 때

--- a/backend/src/main/java/org/example/backend/domain/orders/service/OrderService.java
+++ b/backend/src/main/java/org/example/backend/domain/orders/service/OrderService.java
@@ -1,0 +1,71 @@
+package org.example.backend.domain.orders.service;
+
+import static org.example.backend.domain.orders.model.dto.OrderDto.*;
+import static org.example.backend.global.common.constants.BaseResponseStatus.*;
+
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.backend.domain.board.model.entity.ProductBoard;
+import org.example.backend.domain.board.product.model.entity.Product;
+import org.example.backend.domain.board.product.repository.ProductRepository;
+import org.example.backend.domain.board.repository.ProductBoardRepository;
+import org.example.backend.domain.orders.model.dto.OrderedProductDto;
+import org.example.backend.domain.orders.model.entity.OrderedProduct;
+import org.example.backend.domain.orders.model.entity.Orders;
+import org.example.backend.domain.orders.repository.OrderedProductRepository;
+import org.example.backend.domain.orders.repository.OrdersRepository;
+import org.example.backend.global.exception.InvalidCustomException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class OrderService {
+    private final OrdersRepository ordersRepository;
+    private final OrderedProductRepository orderedProductRepository;
+    private final ProductRepository productRepository;
+    private final ProductBoardRepository productBoardRepository;
+
+    @Transactional
+    public OrderCreateResponse register(OrderRegisterRequest request) {
+
+        validateOrder(request);
+
+        Orders order = OrderRegisterRequest.toEntity(request.getBoardIdx());
+        ordersRepository.save(order);
+
+        List<OrderedProduct> orderedProducts = request.getOrderedProducts().stream()
+                .map(product -> OrderedProductDto.Request.toEntity(product, order))
+                .collect(Collectors.toList());
+
+        orderedProductRepository.saveAll(orderedProducts);
+
+        return OrderCreateResponse.builder()
+                .orderIdx(order.getIdx())
+                .build();
+    }
+
+    public void validateOrder(OrderRegisterRequest order){
+
+        ProductBoard board = productBoardRepository.findById(order.getBoardIdx())
+                .orElseThrow(() -> new InvalidCustomException(ORDER_FAIL_ENVENT_NOT_FOUND));
+
+        if (board.getEndedAt().isBefore(LocalDateTime.now())) {
+            throw new InvalidCustomException(ORDER_FAIL_EXPIRED_EVENT); // 이벤트가 끝났을 때
+        }
+
+        order.getOrderedProducts().forEach((product) -> {
+            Product orderdProduct = productRepository.findById(product.getIdx())
+                    .orElseThrow(() -> new InvalidCustomException(ORDER_FAIL_PRODUCT_NOT_FOUND)); // 해당하는 상품을 찾을 수가 없을 때
+
+            if (product.getQuantity() > orderdProduct.getStock()) {
+                throw new InvalidCustomException(ORDER_CREATE_FAIL_LACK_STOCK); // 재고 수량 없을 때
+            }
+        });
+    }
+}

--- a/backend/src/main/java/org/example/backend/domain/orders/service/OrderService.java
+++ b/backend/src/main/java/org/example/backend/domain/orders/service/OrderService.java
@@ -60,12 +60,14 @@ public class OrderService {
         }
 
         order.getOrderedProducts().forEach((product) -> {
-            Product orderdProduct = productRepository.findById(product.getIdx())
+            Product orderdProduct = productRepository.findByIdWithLock(product.getIdx())
                     .orElseThrow(() -> new InvalidCustomException(ORDER_FAIL_PRODUCT_NOT_FOUND)); // 해당하는 상품을 찾을 수가 없을 때
 
             if (product.getQuantity() > orderdProduct.getStock()) {
                 throw new InvalidCustomException(ORDER_CREATE_FAIL_LACK_STOCK); // 재고 수량 없을 때
             }
+
+            orderdProduct.decreaseStock(product.getQuantity()); // 재고 수량 변경
         });
     }
 }

--- a/backend/src/main/java/org/example/backend/global/common/constants/BaseResponseStatus.java
+++ b/backend/src/main/java/org/example/backend/global/common/constants/BaseResponseStatus.java
@@ -93,7 +93,7 @@ public enum BaseResponseStatus {
     ORDER_FAIL_DETAIL(false, 3010, "주문 상세조회에 실패했습니다."),
     ORDER_FAIL_ENVENT_NOT_FOUND(false, 3011, "주문에 실패했습니다. 해당하든 게시글을 찾을 수 없습니다."),
     ORDER_FAIL_NOT_FOUND(false, 3012, "해당하는 주문을 찾을 수 없습니다."),
-    ORDER_FAIL_INVALID_PRODUCT_PRICE(false, 3013, "주문에 실패했습니다. 해당하든 상품의 가격 정보가 유효하지 않습니다."),
+    ORDER_FAIL_INVALID_PRODUCT_PRICE(false, 3013, "주문에 실패했습니다. 해당하는 상품의 가격 정보가 유효하지 않습니다."),
     ORDER_FAIL_EXPIRED_EVENT(false, 3014, "주문에 실패했습니다. 종료된 이벤트입니다."),
     ORDER_FAIL_PRODUCT_NOT_FOUND(false, 3015, "주문에 실패했습니다. 해당하는 상품을 찾을 수 없습니다."),
 

--- a/backend/src/main/java/org/example/backend/global/common/constants/BaseResponseStatus.java
+++ b/backend/src/main/java/org/example/backend/global/common/constants/BaseResponseStatus.java
@@ -95,6 +95,7 @@ public enum BaseResponseStatus {
     ORDER_FAIL_NOT_FOUND(false, 3012, "해당하는 주문을 찾을 수 없습니다."),
     ORDER_FAIL_INVALID_PRODUCT_PRICE(false, 3013, "주문에 실패했습니다. 해당하든 상품의 가격 정보가 유효하지 않습니다."),
     ORDER_FAIL_EXPIRED_EVENT(false, 3014, "주문에 실패했습니다. 종료된 이벤트입니다."),
+    ORDER_FAIL_PRODUCT_NOT_FOUND(false, 3015, "주문에 실패했습니다. 해당하는 상품을 찾을 수 없습니다."),
 
 
     // 상품게시글 기능 4000

--- a/backend/src/main/java/org/example/backend/global/common/constants/BaseResponseStatus.java
+++ b/backend/src/main/java/org/example/backend/global/common/constants/BaseResponseStatus.java
@@ -91,7 +91,7 @@ public enum BaseResponseStatus {
     ORDER_FAIL_NONIMPUID(false, 3008, "주문에 실패했습니다. 결제여부를 확인해 주세요"),
     ORDER_EDIT_FAIL(false, 3009, "주문정보 수정에 실패했습니다."),
     ORDER_FAIL_DETAIL(false, 3010, "주문 상세조회에 실패했습니다."),
-    ORDER_FAIL_ENVENT_NOT_FOUND(false, 3011, "주문에 실패했습니다. 해당하든 게시글을 찾을 수 없습니다."),
+    ORDER_FAIL_EVENT_NOT_FOUND(false, 3011, "주문에 실패했습니다. 해당하든 게시글을 찾을 수 없습니다."),
     ORDER_FAIL_NOT_FOUND(false, 3012, "해당하는 주문을 찾을 수 없습니다."),
     ORDER_FAIL_INVALID_PRODUCT_PRICE(false, 3013, "주문에 실패했습니다. 해당하는 상품의 가격 정보가 유효하지 않습니다."),
     ORDER_FAIL_EXPIRED_EVENT(false, 3014, "주문에 실패했습니다. 종료된 이벤트입니다."),

--- a/backend/src/main/java/org/example/backend/global/common/constants/SwaggerDescription.java
+++ b/backend/src/main/java/org/example/backend/global/common/constants/SwaggerDescription.java
@@ -10,6 +10,7 @@ public class SwaggerDescription {
             "- 개업일자: 20130716";
     //일반회원가입 설명 틀
     public static final String USER_SIGNUP_REQUEST = "먼저 이메일 인증 요청 후 회원가입 요청을 진행해주세요";
+    public static final String ORDERS_REGISTER_REQUEST = "주문을 등록하는 API 입니다. 먼저 게시글과 상품을 만들고 진행해주세요.";
     //이메일 인증 설명 틀
     public static final String EMAIL_AUTH_REQUEST = "이메일을 입력하면 인증코드를 생성하여 이메일로 발송합니다. 만료기한은 10분입니다.";
 }

--- a/backend/src/main/java/org/example/backend/global/common/constants/SwaggerExamples.java
+++ b/backend/src/main/java/org/example/backend/global/common/constants/SwaggerExamples.java
@@ -36,4 +36,23 @@ public class SwaggerExamples {
        {
            "email": "이메일입력"
        }""";
+
+
+    // 주문 등록 요청 틀
+    public static final String ORDERS_REGISTER_REQUEST = """
+       {
+           "boardIdx" : "게시글 idx 입력",
+           "orderedProducts" : [
+                {
+                    "idx" : "게시글에서 주문한 상품 idx",
+                    "quantity" : "주문한 수량"
+                },
+                {
+                    "idx" : "게시글에서 주문한 상품 idx",
+                    "quantity" : "주문한 수량"
+                }
+           ]
+       }
+    """;
+
 }

--- a/backend/src/main/java/org/example/backend/global/common/constants/SwaggerExamples.java
+++ b/backend/src/main/java/org/example/backend/global/common/constants/SwaggerExamples.java
@@ -40,19 +40,19 @@ public class SwaggerExamples {
 
     // 주문 등록 요청 틀
     public static final String ORDERS_REGISTER_REQUEST = """
-       {
-           "boardIdx" : "게시글 idx 입력",
-           "orderedProducts" : [
-                {
-                    "idx" : "게시글에서 주문한 상품 idx",
-                    "quantity" : "주문한 수량"
-                },
-                {
-                    "idx" : "게시글에서 주문한 상품 idx",
-                    "quantity" : "주문한 수량"
+               {
+                  "boardIdx": 1,
+                  "orderedProducts": [
+                    {
+                      "idx": 1,
+                      "quantity": 100
+                    },
+                    {
+                      "idx": 2,
+                      "quantity": 100
+                    }
+                  ]
                 }
-           ]
-       }
-    """;
+            """;
 
 }

--- a/backend/src/main/java/org/example/backend/global/infra/db/InitDB.java
+++ b/backend/src/main/java/org/example/backend/global/infra/db/InitDB.java
@@ -1,0 +1,88 @@
+package org.example.backend.global.infra.db;
+
+import jakarta.annotation.PostConstruct;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.example.backend.domain.board.category.model.entity.Category;
+import org.example.backend.domain.board.category.repository.CategoryRepository;
+import org.example.backend.domain.board.model.entity.ProductBoard;
+import org.example.backend.domain.board.product.model.entity.Product;
+import org.example.backend.domain.board.product.repository.ProductRepository;
+import org.example.backend.domain.board.repository.ProductBoardRepository;
+import org.example.backend.global.common.constants.BoardStatus;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class InitDB {
+
+    private final CategoryRepository categoryRepository;
+    private final ProductBoardRepository productBoardRepository;
+    private final ProductRepository productRepository;
+
+    private List<Category> categories;
+    private List<ProductBoard> productBoards;
+
+
+    @PostConstruct
+    public void execute() {
+        insertCategory();
+        insertBoard();
+        insertProduct();
+    }
+    private void insertCategory(){
+        List<String> categoryNames = List.of("식품", "의류", "뷰티", "라이프");
+        categories = categoryNames.stream()
+                .map(name -> Category.builder().name(name).build())
+                .collect(Collectors.toList());
+
+       categoryRepository.saveAll(categories);
+    }
+
+    private void insertBoard(){
+
+        if (categories.size() == 0) {
+            return;
+        }
+
+        productBoards = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            productBoards.add(ProductBoard.builder()
+                    .title("[음성명작]500m 고랭지에서 수확한 사과1.3kg[품종:홍로] " + i)
+                    .discountRate(23)
+                    .startedAt(LocalDateTime.now())
+                    .endedAt(LocalDateTime.now().plusDays(1))
+                    .category(categories.get(0))
+                    .productThumbnailUrl("sample-thumnail-url")
+                    .productDetailUrl("sample-detail-url")
+                    .status(BoardStatus.READY.getStatus())
+                    .minimumPrice(15900)
+                    .build());
+        }
+
+        productBoardRepository.saveAll(productBoards);
+    }
+    private void insertProduct() {
+
+        if (productBoards.size() == 0) {
+            return;
+        }
+
+        List<Product> products = new ArrayList<>();
+        for (int i=0; i<productBoards.size();i++) {
+            for (int j=0;j<2;j++) {
+                products.add(Product.builder()
+                        .name("상품 " + j)
+                        .stock(100)
+                        .price((i + 1) * 10000)
+                        .productBoard(productBoards.get(i))
+                        .build());
+            }
+        }
+
+        productRepository.saveAll(products);
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -36,7 +36,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         format_sql: true

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -36,7 +36,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #27 

<br>
 

## 📝 작업 내용

- 주문 등록기능 api 구현 
- 주문 등록 테스트를 위한 더미 데이터 생성(initDB)
- 재고 수량 업데이트 구현(비관적 락 적용)
- 주문 등록 swagger 작성

<br>

## **💬 리뷰 요구사항(선택)**

> category, productBoard, product 더미 데이터를 넣는 initDB 클래스를 생성했습니다. DB 초기화후, 서버 실행해주세요!

- initDB 로 더미데이터 생성한 화면
<img width="500" alt="image" src="https://github.com/user-attachments/assets/ca95a7a1-948e-4468-b82a-958f4019ace8">

<br><br>

- 해당 로컬 DB에서는 게시글 idx 1에 상품 idx 1,2 가 등록되어 있음(로컬 DB 환경마다 다를 수 있으니, 테스트 시 확인 필요)
<img width="300" alt="image" src="https://github.com/user-attachments/assets/a58889ea-bba7-4515-b87a-1bfdc9b9a4b9">

<br><br>

### **✅ 요청 사항**
- swagger에서 요청 보냈을 때, 주문 생성이 제대로 되는지 확인해주세요! (최대 수량 100)
- 주문 수량을 300으로 했을 때, 재고가 부족하다는 에러 코드가 뜨는지 확인해 주세요!
**- swagger 입력할 때, **반드시** board 게시글 idx 에 등록된 상품 idx를 입력해야합니다!** (본인 DB 잘 확인해주세요🙏🏻)
<img width="410" alt="image" src="https://github.com/user-attachments/assets/7587f1bd-e6eb-4c2c-a8d9-0fb8ff16b9a5">

<br>

### 1️⃣ **성공 시 화면**
<img width="500" alt="image" src="https://github.com/user-attachments/assets/d1c47497-b5a8-474d-a6b6-7c0f25750111">

<br>

### **2️⃣ 실패 시 화면**
<img width="500" alt="image" src="https://github.com/user-attachments/assets/03583593-48be-46f1-92fd-b1ae0290d947">



