### PR TITLE
[#95]일반회원정보 조회 페이지 기능 구현

### DIFF
--- a/frontend/src/pages/common/LoginRedirectPage.vue
+++ b/frontend/src/pages/common/LoginRedirectPage.vue
@@ -14,7 +14,6 @@ export default {
   mounted(){
     const query = new URLSearchParams(window.location.search);
     const isSuccess = query.get("isSuccess") === 'true';
-    console.log(isSuccess);
     if(isSuccess){
       const isExist = query.get("isExist") === 'true';
       if (isExist){

--- a/frontend/src/pages/user/MyPage.vue
+++ b/frontend/src/pages/user/MyPage.vue
@@ -20,6 +20,8 @@ import HeaderComponent from "@/components/common/HeaderComponent.vue";
 import MypageAsideComponent from "@/components/mypage/MypageAsideComponent.vue";
 import FooterComponent from "@/components/common/FooterComponent.vue";
 import TitleComponent from "@/components/mypage/TitleComponent.vue";
+import { useUserStore } from '@/stores/useUserStore';
+import { mapStores } from 'pinia';
 
 export default {
   name: "MyPage",
@@ -48,6 +50,16 @@ export default {
       } else if (menu === "address") {
         this.currentTitle = "배송지 관리";
         this.$router.push("/mypage/address");
+      }else if (menu === "info"){
+        this.getUserInfo();
+      }
+      
+    },
+    async getUserInfo(){
+      if(await this.userStore.getDetail()){
+        alert("성공");
+      }else{
+        alert("회원정보를 가져오는데 실패했습니다.");
       }
     },
     updateTitleBasedOnRoute() {
@@ -63,6 +75,9 @@ export default {
         this.$router.push("/mypage/address");
       }
     },
+  },
+  computed: {
+    ...mapStores(useUserStore)
   },
   mounted() {
     this.updateTitleBasedOnRoute(); // 페이지 로드 시 현재 경로에 따라 타이틀 설정

--- a/frontend/src/stores/useUserStore.js
+++ b/frontend/src/stores/useUserStore.js
@@ -15,6 +15,15 @@ export const useUserStore = defineStore("user", {
     userLoginRequest: {
       email: "",
       password: "",
+    },
+    userDetail: {
+      "name": "",
+      "email": "",
+      "address": "",
+      "addressDetail": "",
+      "postNumber": "",
+      "phoneNumber": "",
+      "deliveries": []
     }
 
   }),
@@ -190,6 +199,21 @@ export const useUserStore = defineStore("user", {
       }catch{
         alert("로그아웃 요청 수행중 문제가 발생했습니다.");
       }
+    },
+    async getDetail(){
+      try{
+        let response = await axios.get(backend+"/user/detail", {withCredentials: true});
+        if(response.data.code === 1000){
+          console.log(response.data.result);
+          return true;
+        }else{
+          return false;
+        }
+      }catch{
+        alert("회원정보 조회에 실패했습니다.");
+      }
     }
   },
+
+  
 });

--- a/frontend/src/stores/useUserStore.js
+++ b/frontend/src/stores/useUserStore.js
@@ -204,7 +204,8 @@ export const useUserStore = defineStore("user", {
       try{
         let response = await axios.get(backend+"/user/detail", {withCredentials: true});
         if(response.data.code === 1000){
-          console.log(response.data.result);
+          this.userDetail = response.data.result;
+          console.log(this.userDetail);
           return true;
         }else{
           return false;
@@ -212,7 +213,7 @@ export const useUserStore = defineStore("user", {
       }catch{
         alert("회원정보 조회에 실패했습니다.");
       }
-    }
+    },
   },
 
   


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #95 

<br>
 

## 📝 작업 내용

> 마이페이지 좌측 내정보 메뉴 클릭시 로그인한 회원의 정보를 불러오는 기능 구현

<br>

## **💬 리뷰 요구사항(선택)**

> 페이지가 아직 없어서 기능 동작만 봐주세요~

- 로그인 후 마이페이지 > 내정보 클릭
- 콘솔에 회원가입시 최초 입력한 배송지 정보가 잘 불러와지는지 확인

