### PR TITLE
[#6] 일반회원정보 조회기능 구현

### DIFF
--- a/backend/src/main/java/org/example/backend/domain/user/controller/UserController.java
+++ b/backend/src/main/java/org/example/backend/domain/user/controller/UserController.java
@@ -14,10 +14,9 @@ import org.example.backend.global.common.constants.BaseResponse;
 import org.example.backend.global.common.constants.BaseResponseStatus;
 import org.example.backend.global.common.constants.SwaggerDescription;
 import org.example.backend.global.common.constants.SwaggerExamples;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.example.backend.global.security.custom.model.dto.CustomUserDetails;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/user")
@@ -81,5 +80,14 @@ public class UserController {
         }
 
         return new BaseResponse();
+    }
+
+    @GetMapping("/detail")
+    public BaseResponse<UserDto.UserDetailResponse> getDetail(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+            ){
+        UserDto.UserDetailResponse userDetailResponse =
+                userService.getDetail(userDetails.getUsername(),userDetails.getIdx());
+        return new BaseResponse<>(userDetailResponse);
     }
 }

--- a/backend/src/main/java/org/example/backend/domain/user/model/dto/DeliveryDto.java
+++ b/backend/src/main/java/org/example/backend/domain/user/model/dto/DeliveryDto.java
@@ -1,0 +1,28 @@
+package org.example.backend.domain.user.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class DeliveryDto {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class DeliveryResponse{
+        private Long idx;
+
+        private String name;
+
+        private Boolean isDefault;
+
+        private String address;
+
+        private String addressDetail;
+
+        private String postNumber;
+
+    }
+}

--- a/backend/src/main/java/org/example/backend/domain/user/model/dto/UserDto.java
+++ b/backend/src/main/java/org/example/backend/domain/user/model/dto/UserDto.java
@@ -5,10 +5,12 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.example.backend.domain.user.model.entity.Delivery;
 import org.example.backend.domain.user.model.entity.User;
 import org.example.backend.global.common.constants.Role;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class UserDto {
 
@@ -73,6 +75,17 @@ public class UserDto {
                     .point(0L)
                     .build();
         }
+
+        public Delivery toDeliveryEntity(User user){
+            return Delivery.builder()
+                    .name("집")
+                    .user(user)
+                    .address(this.address)
+                    .addressDetail(this.addressDetail)
+                    .postNumber(this.postNumber)
+                    .isDefault(true)
+                    .build();
+        }
     }
 
     @Getter
@@ -134,6 +147,31 @@ public class UserDto {
                     .point(0L)
                     .build();
         }
+
+        public Delivery toDeliveryEntity(User user){
+            return Delivery.builder()
+                    .name("집")
+                    .user(user)
+                    .address(this.address)
+                    .addressDetail(this.addressDetail)
+                    .postNumber(this.postNumber)
+                    .isDefault(true)
+                    .build();
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class UserDetailResponse{
+        private String name;
+        private String email;
+        private String address;
+        private String addressDetail;
+        private String postNumber;
+        private String phoneNumber;
+        private List<DeliveryDto.DeliveryResponse> deliveries;
     }
 
 }

--- a/backend/src/main/java/org/example/backend/domain/user/model/entity/Delivery.java
+++ b/backend/src/main/java/org/example/backend/domain/user/model/entity/Delivery.java
@@ -6,6 +6,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.example.backend.domain.user.model.dto.DeliveryDto;
+import org.example.backend.domain.user.model.dto.UserDto;
 
 @Entity
 @Getter
@@ -32,4 +34,14 @@ public class Delivery {
     @JoinColumn(name = "user_idx")
     private User user;
 
+    public DeliveryDto.DeliveryResponse toDeliveryResponse(){
+        return DeliveryDto.DeliveryResponse.builder()
+                .idx(this.idx)
+                .isDefault(this.isDefault)
+                .address(this.address)
+                .addressDetail(this.addressDetail)
+                .postNumber(this.postNumber)
+                .name(this.name)
+                .build();
+    }
 }

--- a/backend/src/main/java/org/example/backend/domain/user/model/entity/User.java
+++ b/backend/src/main/java/org/example/backend/domain/user/model/entity/User.java
@@ -5,9 +5,11 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.example.backend.domain.user.model.dto.UserDto;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Entity
 @Getter
@@ -46,8 +48,17 @@ public class User {
     private String role;
 
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "user")
-    private List<Delivery> deliveryList;
+    private List<Delivery> deliveries;
 
-
-
+    public UserDto.UserDetailResponse toUserDetailResponse(){
+        return UserDto.UserDetailResponse.builder()
+                .name(this.name)
+                .email(this.email)
+                .address(this.address)
+                .addressDetail(this.addressDetail)
+                .postNumber(this.postNumber)
+                .phoneNumber(this.phoneNumber)
+                .deliveries(this.deliveries.stream().map(Delivery::toDeliveryResponse).collect(Collectors.toList()))
+                .build();
+    }
 }

--- a/backend/src/main/java/org/example/backend/domain/user/repository/UserRepository.java
+++ b/backend/src/main/java/org/example/backend/domain/user/repository/UserRepository.java
@@ -9,4 +9,6 @@ import java.util.Optional;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
+
+    Optional<User> findByEmailAndIdx(String email, Long idx);
 }

--- a/backend/src/main/java/org/example/backend/domain/user/service/UserService.java
+++ b/backend/src/main/java/org/example/backend/domain/user/service/UserService.java
@@ -5,13 +5,12 @@ import lombok.RequiredArgsConstructor;
 import org.example.backend.domain.user.model.dto.UserDto;
 import org.example.backend.domain.user.model.entity.User;
 import org.example.backend.domain.user.repository.DeliveryRepository;
-import org.example.backend.domain.user.repository.UserAuthTokenRepository;
 import org.example.backend.domain.user.repository.UserRepository;
 import org.example.backend.global.common.constants.BaseResponseStatus;
 import org.example.backend.global.exception.InvalidCustomException;
-import org.springframework.context.annotation.Bean;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
@@ -30,15 +29,27 @@ public class UserService {
             throw new InvalidCustomException(BaseResponseStatus.USER_SIGNUP_FAIL_ALREADY_EXIST);
         }
     }
+
+    public UserDto.UserDetailResponse getDetail(String email, Long idx){
+        User user = userRepository.findByEmailAndIdx(email,idx).orElseThrow(
+                () -> new InvalidCustomException(BaseResponseStatus.USER_DETAIL_FAIL_USER_NOT_FOUND)
+        );
+        return user.toUserDetailResponse();
+    }
+
+    @Transactional
     public boolean signup(UserDto.UserSignupRequest request) {
         User newUser = userRepository.save(request.toEntity(passwordEncoder.encode(request.getPassword())));
         //회원가입시 입력한 주소를 기본배송지로 배송지목록에 추가
+        deliveryRepository.save(request.toDeliveryEntity(newUser));
         return true;
     }
 
 
+    @Transactional
     public boolean socialSignup(UserDto.SocialSignupRequest socialSignupRequest) {
         User newUser = userRepository.save(socialSignupRequest.toEntity());
+        deliveryRepository.save(socialSignupRequest.toDeliveryEntity(newUser));
         return true;
     }
 }

--- a/backend/src/main/java/org/example/backend/global/common/constants/BaseResponseStatus.java
+++ b/backend/src/main/java/org/example/backend/global/common/constants/BaseResponseStatus.java
@@ -79,7 +79,7 @@ public enum BaseResponseStatus {
     EMAIL_VERIFY_FAIL_CAN_NOT_SEND(false, 2061, "인증메일 발송에 실패했습니다."),
     USER_SIGNUP_FAIL_ALREADY_EXIST(false, 2062, "이미 가입된 이메일입니다."),
     USER_LOGIN_FAIL_UNAUTHORIZED_REG_NUMBER(false, 2063, "로그인에 실패했습니다. 사업자등록번호 인증 정보가 없는 회원입니다."),
-
+    USER_DETAIL_FAIL_USER_NOT_FOUND(false, 2064, "회원정보 조회에 실패했습니다. 해당 정보로 가입된 회원정보가 없습니다."),
 
     // 주문 기능 3000
     ORDER_FAIL_LIST(false, 3001, "주문내역 조회에 실패했습니다."),

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -85,7 +85,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #6

<br>
 

## 📝 작업 내용

- 회원가입시 자동으로 입력한 주소를 배송지로 추가 (집, 기본배송지)
- 내정보 조회시 로그인한 회원으로 등록된 배송지 정보와 회원정보를 응답

<br>

## **💬 리뷰 요구사항(선택)**

> frontend/feature/user/mypage-detail 브랜치와 함께 테스트해주세요~

- 회원가입시 입력한 주소정보로 배송지가 최초 하나 등록되는지
- 등록된 배송지가 기본배송지로 설정되어있고 이름이 집으로 등록되는지
- 회원정보 조회시 로그인한 회원의 정보를 잘 불러오는지
