### PR TITLE
[#180] 배송지 삭제 기능 구현

### DIFF
--- a/backend/src/main/java/org/example/backend/domain/delivery/controller/DeliveryController.java
+++ b/backend/src/main/java/org/example/backend/domain/delivery/controller/DeliveryController.java
@@ -4,6 +4,8 @@ import lombok.RequiredArgsConstructor;
 import org.example.backend.domain.delivery.model.dto.DeliveryDto;
 import org.example.backend.domain.delivery.service.DeliveryService;
 import org.example.backend.global.common.constants.BaseResponse;
+import org.example.backend.global.common.constants.BaseResponseStatus;
+import org.example.backend.global.exception.InvalidCustomException;
 import org.example.backend.global.security.custom.model.dto.CustomUserDetails;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -30,6 +32,17 @@ public class DeliveryController {
             @RequestBody DeliveryDto.CreateDeliveryRequest request
     ){
         deliveryService.createDelivery(userDetails.getIdx(),request);
+        return new BaseResponse();
+    }
+
+    @DeleteMapping("/{idx}")
+    public BaseResponse deleteDelivery(
+            @PathVariable Long idx
+    ){
+        if(!deliveryService.isExist(idx)){
+        throw new InvalidCustomException(BaseResponseStatus.USER_DELIVERY_REMOVE_FAIL_NO_MATCH_DELIVERY);
+        }
+        deliveryService.deleteDelivery(idx);
         return new BaseResponse();
     }
 

--- a/backend/src/main/java/org/example/backend/domain/delivery/repository/DeliveryRepository.java
+++ b/backend/src/main/java/org/example/backend/domain/delivery/repository/DeliveryRepository.java
@@ -10,4 +10,8 @@ import java.util.Optional;
 @Repository
 public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
     Optional<List<Delivery>> findAllByUserIdx(Long idx);
+
+    void deleteByIdx(Long idx);
+
+    Optional<Delivery> findByIdx(Long idx);
 }

--- a/backend/src/main/java/org/example/backend/domain/delivery/service/DeliveryService.java
+++ b/backend/src/main/java/org/example/backend/domain/delivery/service/DeliveryService.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -65,5 +66,17 @@ public class DeliveryService {
                     return delivery;
                 })
                 .orElse(null);
+    }
+
+    public void deleteDelivery(Long idx) {
+        deliveryRepository.deleteById(idx);
+    }
+
+    public boolean isExist(Long idx) {
+        Optional<Delivery> optionalDelivery = deliveryRepository.findByIdx(idx);
+        if (optionalDelivery.isEmpty()){
+            return false;
+        }
+        return true;
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #180 

<br>
 

## 📝 작업 내용

> 배송지 삭제 기능 구현

- 배송지 관리 페이지에서 배송지정보가 0개일 경우 문구 출력, 저장 버튼 안보이게 처리
- 수정버튼 클릭 후 삭제 클릭 시 해당 배송지 삭제


<br>

## **💬 리뷰 요구사항(선택)**

> frontend/feature/user/address-delete 프론트엔드 브랜치와 함께 테스트 해주세요

- 배송지 관리 페이지에서 배송지 수정 버튼 클릭후 삭제시도하면 잘 삭제 되는지
- 배송지가 0개면 문구출력과 함께 저장버튼 사라지는지
