### PR TITLE
[#60] 문의 목록 조회 기능 구현

### DIFF
--- a/frontend/src/components/board/BoardDetailNavComponent.vue
+++ b/frontend/src/components/board/BoardDetailNavComponent.vue
@@ -2,37 +2,27 @@
   <div class="css-16c0d8l">
     <nav class="css-1le17tz en4zazl1">
       <ul class="css-tse2s2 en4zazl0">
-        <li
-          :class="[
+        <li :class="[
             'css-1tzhzcg',
             'efe6b6j1',
             'tab',
             { active: activeTab === 'description' },
-          ]"
-          @click.prevent="activeTab = 'description'"
-        >
+          ]" @click.prevent="activeTab = 'description'">
           <a class="css-1t0ft7s efe6b6j0"><span class="name">상품설명</span></a>
         </li>
-        <li
-          :class="[
+        <li :class="[
             'css-1tzhzcg',
             'efe6b6j1',
             'tab',
             { active: activeTab === 'inquiries' },
-          ]"
-          @click.prevent="loadInquiries"
-        >
+          ]" @click.prevent="loadInquiries">
           <a class="css-1t0ft7s efe6b6j0"><span class="name">문의</span></a>
         </li>
       </ul>
     </nav>
     <!-- 상품 상세 설명 section -->
     <div class="css-0 el27cq1">
-      <div
-        id="description"
-        class="css-18eozqj el27cq0"
-        v-show="activeTab === 'description'"
-      >
+      <div id="description" class="css-18eozqj el27cq0" v-show="activeTab === 'description'">
         <div class="css-1d3w5wq e1d86arr0">
           <div class="css-1lyi66c">
             <div class="goods_wrap">
@@ -40,8 +30,7 @@
                 <div class="context">
                   <div class="pic">
                     <img
-                      src="https://img-cf.kurly.com/hdims/resize/%3E1010x/quality/90/src/shop/data/goodsview/20240829/gv10001551896_1.jpg"
-                    />
+                      src="https://img-cf.kurly.com/hdims/resize/%3E1010x/quality/90/src/shop/data/goodsview/20240829/gv10001551896_1.jpg" />
                   </div>
                   <p class="words"></p>
                 </div>
@@ -56,13 +45,7 @@
     <!-- 문의 하기 리스트 section -->
     <div class="css-30tvht eewa3w91" v-show="activeTab === 'inquiries'">
       <div class="css-17juoyc eewa3w90">
-        <button
-          class="css-mhrz8m e4nu7ef3"
-          type="button"
-          width="120"
-          height="40"
-          @click="openNewInquiryModal"
-        >
+        <button class="css-mhrz8m e4nu7ef3" type="button" width="120" height="40" @click="openNewInquiryModal">
           <span class="css-nytqmg e4nu7ef1">문의하기</span>
         </button>
       </div>
@@ -89,13 +72,11 @@
           <tr @click="toggleInquiry(index)" class="css-atz965 e1l5ky7y9">
             <td class="css-1brd6ns e1l5ky7y8">{{ row.title }}</td>
             <td class="css-1pkqelu e1l5ky7y7">{{ maskAuthorName(row.userName) }}</td>
-            <td class="css-1pkqelu e1l5ky7y6">{{ row.modifiedAt ? formatDate(row.modifiedAt) : formatDate(row.createdAt) }}</td>
+            <td class="css-1pkqelu e1l5ky7y6">{{ row.modifiedAt ? formatDate(row.modifiedAt) : formatDate(row.createdAt)
+              }}</td>
             <td class="css-bhr3cq e1l5ky7y5">{{ row.answerStatus }}</td>
           </tr>
-          <tr
-            v-show="expandedInquiryIndex === index"
-            class="css-1mvq381 e61d7mt0"
-          >
+          <tr v-show="expandedInquiryIndex === index" class="css-1mvq381 e61d7mt0">
             <td colspan="4">
               <div class="css-tnubsz e1ptpt003">
                 <div class="css-1n83etr e1ptpt002">
@@ -131,20 +112,12 @@
     </div>
 
     <!-- 새 문의 작성 모달 -->
-    <QnaRegisterModalComponent
-      v-if="showNewInquiryModal"
-      @close="closeModal"
-      @submit="addNewInquiry"
-    />
+    <QnaRegisterModalComponent v-if="showNewInquiryModal" @close="closeModal" @submit="addNewInquiry"
+      :productBoardIdx="productBoardIdx" :thumbnail="thumbnails[0].src" :title="productTitle" />
 
     <!-- 수정 모달 -->
-    <QnaRegisterModalComponent
-      v-if="showEditInquiryModal"
-      :initialSubject="selectedInquiry.title"
-      :initialContent="selectedInquiry.content"
-      @close="closeModal"
-      @submit="updateInquiry"
-    />
+    <QnaRegisterModalComponent v-if="showEditInquiryModal" :initialSubject="selectedInquiry.title"
+      :initialContent="selectedInquiry.content" @close="closeModal" @submit="updateInquiry" />
   </div>
 </template>
 
@@ -157,6 +130,20 @@ export default {
   name: "BoardDetailNavComponent",
   computed: {
     ...mapStores(useQnaStore),
+  },
+  props: {
+    thumbnails: {
+      type: Array,
+      required: true,
+    },
+    productBoardIdx: {
+      type: Number,
+      required: true,
+    },
+    productTitle: {
+      type: String,
+      required: true,
+    },
   },
   data() {
     return {

--- a/frontend/src/components/board/BoardDetailNavComponent.vue
+++ b/frontend/src/components/board/BoardDetailNavComponent.vue
@@ -20,7 +20,7 @@
             'tab',
             { active: activeTab === 'inquiries' },
           ]"
-          @click.prevent="activeTab = 'inquiries'"
+          @click.prevent="loadInquiries"
         >
           <a class="css-1t0ft7s efe6b6j0"><span class="name">문의</span></a>
         </li>
@@ -149,17 +149,15 @@
 </template>
 
 <script>
+import { useQnaStore } from "@/stores/useQnaStore";
 import QnaRegisterModalComponent from "../qna/QnaRegisterModalComponent.vue";
+import { mapStores } from "pinia";
 
 export default {
   name: "BoardDetailNavComponent",
-  props: {
-    tableData: {
-      type: Array,
-      required: true,
-    },
+  computed: {
+    ...mapStores(useQnaStore),
   },
-
   data() {
     return {
       activeTab: "description",
@@ -171,12 +169,18 @@ export default {
         title: "",
         content: "",
       },
-      localTableData: [...this.tableData],
+      localTableData: [],
       expandedInquiryIndex: null,
       editingIndex: null, // 수정할 문의 인덱스
     };
   },
   methods: {
+    loadInquiries() {
+      this.activeTab = "inquiries"; // 문의 탭 활성화
+      this.qnaStore.fetchInquiries().then(() => {
+        this.localTableData = this.qnaStore.inquiries;
+      });
+    },
     formatDate(dateString) {
       const date = new Date(dateString);
       return date.toLocaleDateString("ko-KR", {

--- a/frontend/src/components/qna/QnaRegisterModalComponent.vue
+++ b/frontend/src/components/qna/QnaRegisterModalComponent.vue
@@ -90,6 +90,8 @@
 
 <script>
 import axios from 'axios';
+import { useQnaStore } from "@/stores/useQnaStore";
+import { mapStores } from "pinia";
 
 export default {
     name: "QnaRegisterModalComponent",
@@ -122,7 +124,11 @@ export default {
     computed: {
         isFormValid() {
             return this.subject.trim().length >= 2 && this.content.trim().length >= 5;
-        }
+        },
+        ...mapStores(useQnaStore),
+        localTableData() {
+            return this.qnaStore.inquiries;
+        },
     },
     methods: {
         closeModal() {

--- a/frontend/src/components/qna/QnaRegisterModalComponent.vue
+++ b/frontend/src/components/qna/QnaRegisterModalComponent.vue
@@ -15,11 +15,10 @@
                         </div>
                         <div class="css-1tm481w eell72m3">
                             <div class="css-l4dbne eell72m2">
-                                <img src="https://product-image.kurly.com/product/image/7a79c0a2-31c7-4cb4-9c93-4ebded5e42b8.jpeg"
-                                    class="css-1vpfo16 eell72m1">
+                                <img :src="thumbnail" class="css-1vpfo16 eell72m1">
                             </div>
                             <div class="css-1mysn55 eell72m0">
-                                <span>[에스티 로더] 갈색병 세럼 50ml 기획세트 (+15ml*3ea 추가 증정)</span>
+                                <span>{{title}}</span>
                             </div>
                         </div>
                         <div class="css-4qu8li e43j10r2">
@@ -103,7 +102,15 @@ export default {
         initialContent: {
             type: String,
             default: ""
-        }
+        },
+        thumbnail: {
+            type: String,
+            required: true
+        },
+        title: {
+            type: String,
+            required: true
+        },
     },
     data() {
         return {

--- a/frontend/src/pages/user/board/BoardDetailPage.vue
+++ b/frontend/src/pages/user/board/BoardDetailPage.vue
@@ -7,7 +7,8 @@
           <BoardDetailThumnailComponent :thumbnails="thumbnails" />
           <BoardDetailProductInfoComponent @submitOrder="submitOrder" />
         </main>
-        <BoardDetailNavComponent />
+        <BoardDetailNavComponent :thumbnails="thumbnails" :productBoardIdx="productBoardIdx"
+          :productTitle="productTitle" />
       </div>
     </div>
   </div>
@@ -46,7 +47,8 @@ export default {
           src: "https://pbs.twimg.com/media/EE0R8XcU0AAlbth.jpg",
         },
       ],
-
+      productBoardIdx: 1, // 추후에 실제 상품의 boardIdx로 변경
+      productTitle: "[음성명작]500m 고랭지에서 수확한 사과1.3kg[품종: 홍로]"
     };
   },
   methods: {

--- a/frontend/src/pages/user/board/BoardDetailPage.vue
+++ b/frontend/src/pages/user/board/BoardDetailPage.vue
@@ -7,7 +7,7 @@
           <BoardDetailThumnailComponent :thumbnails="thumbnails" />
           <BoardDetailProductInfoComponent @submitOrder="submitOrder" />
         </main>
-        <BoardDetailNavComponent :tableData="tableData" />
+        <BoardDetailNavComponent />
       </div>
     </div>
   </div>
@@ -20,12 +20,11 @@ import FooterComponent from "@/components/common/FooterComponent.vue";
 import BoardDetailThumnailComponent from "@/components/board/BoardDetailThumnailComponent.vue";
 import BoardDetailProductInfoComponent from "@/components/board/BoardDetailProductInfoComponent.vue";
 import BoardDetailNavComponent from "@/components/board/BoardDetailNavComponent.vue";
-
 import { useOrderStore } from "@/stores/useOrderStore";
 import { mapStores } from "pinia";
 
 export default {
-  name: "OrdersPage",
+  name: "BoardDetailPage",
   components: {
     HeaderComponent,
     FooterComponent,

--- a/frontend/src/stores/useQnaStore.js
+++ b/frontend/src/stores/useQnaStore.js
@@ -10,7 +10,6 @@ export const useQnaStore = defineStore("qna", {
         async fetchInquiries() {
             try {
                 const response = await axios.get('/api/qna/question/list'); // 실제 API URL
-                console.log(response.data.result); // API 응답 로그 출력
                 if (response.data.isSuccess) {
                     this.inquiries = response.data.result;
                 } else {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #60

<br>
 

## 📝 작업 내용

> 상품 게시글 상세 조회 화면이 표시되지 않는 문제를 해결하고, `문의` 탭을 클릭했을 때 문의 목록이 조회되도록 데이터 바인딩을 구현

<br>

## **💬 리뷰 요구사항(선택)**

> `board/detail/1`경로에서, `backend/fix/user/qna-register` 브랜치와 같이 실행해서 테스트 부탁드립니다.
- [ ] `board/detail/1`경로로 이동했을 때 화면이 정상적으로 표시되는지
- [ ] `문의` 탭을 눌렀을 때, DB에 저장된 문의 목록이 제대로 화면에 표시되는지
- [ ] 새로 문의를 등록했을 때, question 테이블에 정상적으로 저장되고 화면에 반영되는지 확인 부탁드립니다!