### PR TITLE
[#13] 기본배송지 등록 기능 구현

### DIFF
--- a/backend/src/main/java/org/example/backend/domain/delivery/controller/DeliveryController.java
+++ b/backend/src/main/java/org/example/backend/domain/delivery/controller/DeliveryController.java
@@ -39,10 +39,26 @@ public class DeliveryController {
     public BaseResponse deleteDelivery(
             @PathVariable Long idx
     ){
+        if (idx == null || idx <= 0){
+            throw new InvalidCustomException(BaseResponseStatus.FAIL);
+        }
         if(!deliveryService.isExist(idx)){
         throw new InvalidCustomException(BaseResponseStatus.USER_DELIVERY_REMOVE_FAIL_NO_MATCH_DELIVERY);
         }
         deliveryService.deleteDelivery(idx);
+        return new BaseResponse();
+    }
+
+    @PatchMapping("")
+    public BaseResponse setDefault(
+            @RequestBody DeliveryDto.SetDefaultRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ){
+        if (request.getIdx() == null || request.getIdx() <= 0){
+            throw new InvalidCustomException(BaseResponseStatus.FAIL);
+        }
+        deliveryService.setDefault(request.getIdx(), userDetails.getIdx());
+
         return new BaseResponse();
     }
 

--- a/backend/src/main/java/org/example/backend/domain/delivery/model/dto/DeliveryDto.java
+++ b/backend/src/main/java/org/example/backend/domain/delivery/model/dto/DeliveryDto.java
@@ -54,4 +54,12 @@ public class DeliveryDto {
                     .build();
         }
     }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class SetDefaultRequest{
+        private Long idx;
+    }
 }

--- a/backend/src/main/java/org/example/backend/domain/delivery/model/entity/Delivery.java
+++ b/backend/src/main/java/org/example/backend/domain/delivery/model/entity/Delivery.java
@@ -45,7 +45,7 @@ public class Delivery {
                 .build();
     }
 
-    public void setIsDefault(Boolean aDefault) {
-        isDefault = aDefault;
+    public void setIsDefault(Boolean asDefault) {
+        isDefault = asDefault;
     }
 }

--- a/backend/src/main/java/org/example/backend/domain/delivery/service/DeliveryService.java
+++ b/backend/src/main/java/org/example/backend/domain/delivery/service/DeliveryService.java
@@ -97,6 +97,7 @@ public class DeliveryService {
     //기존 기본배송지 여부를 확인
     //있으면 false처리 후 넘겨받은 idx의 배송지를 true로 변경
     //저장
+    @Transactional
     public void setDefault(Long idx,Long userIdx) {
         List<Delivery> deliveries = deliveryRepository.findAllByUserIdx(userIdx).orElseThrow(
                 () -> new InvalidCustomException(BaseResponseStatus.USER_DELIVERY_EDIT_FAIL)

--- a/backend/src/main/java/org/example/backend/domain/delivery/service/DeliveryService.java
+++ b/backend/src/main/java/org/example/backend/domain/delivery/service/DeliveryService.java
@@ -43,6 +43,7 @@ public class DeliveryService {
         if (request.getIsDefault()){
             if (isDefaultExist(user.getDeliveries())){
                 Delivery defaultDelivery = getDefaultDelivery(user.getDeliveries());
+                defaultDelivery.setIsDefault(false);
                 //기존 기본배송지 false로 업데이트
                 deliveryRepository.save(defaultDelivery);
             }
@@ -61,10 +62,6 @@ public class DeliveryService {
         return deliveries.stream()
                 .filter(Delivery::getIsDefault)
                 .findFirst()
-                .map(delivery -> {
-                    delivery.setIsDefault(false);
-                    return delivery;
-                })
                 .orElse(null);
     }
 
@@ -107,8 +104,9 @@ public class DeliveryService {
             throw new InvalidCustomException(BaseResponseStatus.USER_DELIVERY_EDIT_FAIL);
         }
         if(isDefaultExist(deliveries)){
-            //기존 기본배송지를 false로 바꿔서 반환
+            //기존 기본배송지를 false로 변경 후 저장
             Delivery existingDefaultDelivery = getDefaultDelivery(deliveries);
+            existingDefaultDelivery.setIsDefault(false);
             deliveryRepository.save(existingDefaultDelivery);
         }
         newDefaultDelivery.setIsDefault(true);

--- a/backend/src/main/java/org/example/backend/domain/delivery/service/DeliveryService.java
+++ b/backend/src/main/java/org/example/backend/domain/delivery/service/DeliveryService.java
@@ -57,7 +57,7 @@ public class DeliveryService {
                 .anyMatch(Delivery::getIsDefault);
     }
     public Delivery getDefaultDelivery(List<Delivery> deliveries) {
-        //받아온 리스트에서 isDefault가 true인 객체의 해당 값을 true로 바꾸고 반환
+        //받아온 리스트에서 isDefault가 true인 객체의 해당 값을 false로 바꾸고 반환
         return deliveries.stream()
                 .filter(Delivery::getIsDefault)
                 .findFirst()
@@ -68,15 +68,49 @@ public class DeliveryService {
                 .orElse(null);
     }
 
+    //배송지 삭제
     public void deleteDelivery(Long idx) {
         deliveryRepository.deleteById(idx);
     }
 
+    //idx로 단건조회 후 존재여부 반환
     public boolean isExist(Long idx) {
         Optional<Delivery> optionalDelivery = deliveryRepository.findByIdx(idx);
         if (optionalDelivery.isEmpty()){
             return false;
         }
         return true;
+    }
+
+    //조회된 list중 해당 idx로 등록된 배송지가 있으면 배송지 반환
+    public Delivery isExist(List<Delivery> deliveries, Long idx){
+        for (Delivery d : deliveries){
+            if (d.getIdx() == idx){
+                return d;
+            }
+        }
+        return null;
+    }
+
+    //회원정보로 배송지목록 조회
+    //idx에 해당하는 배송지가 있는지 체크
+    //기존 기본배송지 여부를 확인
+    //있으면 false처리 후 넘겨받은 idx의 배송지를 true로 변경
+    //저장
+    public void setDefault(Long idx,Long userIdx) {
+        List<Delivery> deliveries = deliveryRepository.findAllByUserIdx(userIdx).orElseThrow(
+                () -> new InvalidCustomException(BaseResponseStatus.USER_DELIVERY_EDIT_FAIL)
+        );
+        Delivery newDefaultDelivery = isExist(deliveries, idx);
+        if (newDefaultDelivery == null){
+            throw new InvalidCustomException(BaseResponseStatus.USER_DELIVERY_EDIT_FAIL);
+        }
+        if(isDefaultExist(deliveries)){
+            //기존 기본배송지를 false로 바꿔서 반환
+            Delivery existingDefaultDelivery = getDefaultDelivery(deliveries);
+            deliveryRepository.save(existingDefaultDelivery);
+        }
+        newDefaultDelivery.setIsDefault(true);
+        deliveryRepository.save(newDefaultDelivery);
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #13 

<br>
 

## 📝 작업 내용

> 기본 배송지 등록 기능 구현

- 요청시 기존에 등록된 기본 배송지를 일반 배송지로 변경
- 새롭게 요청한 배송지를 기본 배송지로 설정

<br>

## **💬 리뷰 요구사항(선택)**

> frontend/feature/user/delivery-default와 함께 테스트 부탁드려요~

- 기존에 등록된 기본배송지를 일반배송지로 잘 변경하는지
- 새롭게 등록된 기본배송지가 기본배송지로 잘 변경되는지

DB에 잘 적용되는지 위주로 확인 부탁드려요~
