### PR TITLE
[#94] 배송지 관리기능 구현 - 기본 배송지 설정

### DIFF
--- a/frontend/src/components/mypage/AddressEditModalComponent.vue
+++ b/frontend/src/components/mypage/AddressEditModalComponent.vue
@@ -34,7 +34,7 @@
           </div>
           <div type="recent" class="css-1y14kop e1k348230">
             <button
-              @click="saveEditedAddress"
+              @click="validateAndSave"
               class="css-10voksq e4nu7ef3"
               type="button"
               height="44"
@@ -62,6 +62,7 @@
 <script>
 import { useUserStore } from "@/stores/useUserStore";
 import { mapStores } from "pinia";
+import { Validator } from "@/util/validator";
 export default {
   name: "AddressEditModalComponent",
   data() {
@@ -117,6 +118,18 @@ export default {
         this.editedAddress.isDefault === this.oldAddress.isDefault
       );
     },
+    validateAndSave() {
+      try {
+        new Validator(this.editedAddress.name, "배송지명을 입력해 주세요").isNotEmpty();
+        new Validator(this.editedAddress.postNumber, "우편번호를 입력해 주세요").isNotEmpty();
+        new Validator(this.editedAddress.address, "주소를 입력해 주세요").isNotEmpty();
+        new Validator(this.editedAddress.addressDetail, "상세주소를 입력해 주세요").isNotEmpty();
+        this.saveEditedAddress();
+      } catch (error) {
+        // 검증 실패 시 에러 메시지 출력
+        alert(error.message);
+      }
+    },
     async deleteOne(){
       if(this.editedAddress.idx === null){
         alert("유효하지 않은 배송지입니다.");
@@ -127,6 +140,9 @@ export default {
         }
         this.closeModal();
       }
+    },
+    validateAll(){
+
     }
   },
 };

--- a/frontend/src/components/mypage/AddressModalComponent.vue
+++ b/frontend/src/components/mypage/AddressModalComponent.vue
@@ -45,7 +45,7 @@
                   </div><span>기본 배송지로 저장</span>
                 </label></div>
             </div>
-            <button @click="saveDelivery" class="css-10voksq e4nu7ef3" type="button" height="44" radius="3">
+            <button @click="validateAndSave" class="css-10voksq e4nu7ef3" type="button" height="44" radius="3">
               <span class="css-nytqmg e4nu7ef1">저장</span>
             </button>
           </div>
@@ -58,6 +58,7 @@
 <script>
 import { useUserStore } from '@/stores/useUserStore';
 import { mapStores } from 'pinia';
+import { Validator } from '@/util/validator';
 export default {
   name: "AddressModalComponent",
   data() {
@@ -95,8 +96,19 @@ export default {
         top: window.screen.height / 2 - height / 2,
       });
     },
+    validateAndSave() {
+      try {
+        new Validator(this.delivery.name, "배송지명을 입력해 주세요").isNotEmpty();
+        new Validator(this.delivery.postNumber, "우편번호를 입력해 주세요").isNotEmpty();
+        new Validator(this.delivery.address, "주소를 입력해 주세요").isNotEmpty();
+        new Validator(this.delivery.addressDetail, "상세주소를 입력해 주세요").isNotEmpty();
+
+        this.saveDelivery();
+      } catch (error) {
+        alert(error.message);
+      }
+    },
     saveDelivery() {
-      console.log(this.delivery);
       this.$emit("saveDelivery", this.delivery);
       this.closeModal();
     },

--- a/frontend/src/components/mypage/MypageAddressComponent.vue
+++ b/frontend/src/components/mypage/MypageAddressComponent.vue
@@ -73,7 +73,7 @@
     </div>
   </div>
   <div v-if="userStore.userDetail.deliveries.length !== 0" class="save-address-container">
-    <button class="save-address">저장하기</button>
+    <button class="save-address" @click="setDefault">기본 배송지로 설정</button>
   </div>
 </template>
 
@@ -140,6 +140,16 @@ export default {
       
       if (defaultDeliveryIndex !== -1) {
         this.selectedAddress = defaultDeliveryIndex;
+        this.selectedDelivery = this.userStore.userDetail.deliveries[defaultDeliveryIndex];
+      }
+    },
+    async setDefault(){
+      if(!this.selectedDelivery.isDefault){
+        if(await this.userStore.setIsDefault(this.selectedDelivery.idx)){
+          await this.userStore.getDeliveryList();
+        }else{
+          alert("기본배송지 설정에 실패했습니다.");
+        }
       }
     }
   },
@@ -320,6 +330,7 @@ ul {
     font-weight: 600;
     font-size: 12px;
     text-align: center;
+    margin-top:5px;
 }
 
 .empty-notice {

--- a/frontend/src/components/user/UserSignupComponent.vue
+++ b/frontend/src/components/user/UserSignupComponent.vue
@@ -358,7 +358,6 @@ export default {
         // 이메일 인증 코드 검증
         new Validator(this.signupRequest.emailCode, "이메일 인증코드를 입력해주세요.").isNotEmpty();
         
-        console.log(this.signupRequest.password);
         // 비밀번호 검증
         new Validator(this.signupRequest.password, "비밀번호를 입력해주세요.")
           .isNotEmpty()
@@ -392,7 +391,6 @@ export default {
 
         return true; // 모든 검증 통과
       } catch (error) {
-        alert(error.message);
         return false;
       }
 

--- a/frontend/src/stores/useUserStore.js
+++ b/frontend/src/stores/useUserStore.js
@@ -205,7 +205,6 @@ export const useUserStore = defineStore("user", {
         let response = await axios.get(backend+"/user/detail", {withCredentials: true});
         if(response.data.code === 1000){
           this.userDetail = response.data.result;
-          console.log(this.userDetail);
           return true;
         }else{
           return false;
@@ -220,7 +219,6 @@ export const useUserStore = defineStore("user", {
         let response = await axios.get(backend+"/delivery/list", {withCredentials: true});
         if(response.data.code === 1000){
           this.userDetail.deliveries = response.data.result;
-          console.log(this.userDetail.deliveries);
           return true;
         }else{
           return false;
@@ -266,6 +264,17 @@ export const useUserStore = defineStore("user", {
         return false;
       }
       
+    },
+    async setIsDefault(idx){
+      try{
+        let response = await axios.patch(backend+"/delivery",{idx:idx},{withCredentials:true});
+        if (response.data.code != 1000){
+          return false;
+        }
+        return true;
+      }catch{
+        return false;
+      }
     }
   },
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #94 

<br>
 

## 📝 작업 내용

> 기본 배송지 등록 기능 구현

- 요청시 기존에 등록된 기본 배송지를 일반 배송지로 변경
- 새롭게 요청한 배송지를 기본 배송지로 설정
- 설정된 기본 배송지에 기본배송지 태그 이동하도록 구현

<br>

## **💬 리뷰 요구사항(선택)**

> backend/feature/user/delivery-default와 함께 테스트 부탁드려요~

- 기존에 등록된 기본배송지를 일반배송지로 잘 변경하는지
- 새롭게 등록된 기본배송지가 기본배송지로 잘 변경되는지
- 기본배송지 태그가 잘 이동하는지
- 기본배송지 태그가 실제 DB의 기본배송지와 일치하는 곳에 달려있는지
