### PR TITLE
[#189] 문의 삭제 기능 구현

### DIFF
--- a/frontend/src/components/board/BoardDetailNavComponent.vue
+++ b/frontend/src/components/board/BoardDetailNavComponent.vue
@@ -90,7 +90,7 @@
                 <div class="css-1j49yxi e11ufodi1"
                   v-if="row.answerStatus !== '답변완료' && row.email === this.userEmail">
                   <button type=" button" @click="openEditModal(index)">수정</button>
-                  <button type="button" class="css-1ankuif e11ufodi0" @click="deleteInquiry(index)">삭제</button>
+                  <button type="button" class="css-1ankuif e11ufodi0" @click="deleteInquiry(row.idx, index)">삭제</button>
                 </div>
               </div>
               <div class="css-tnubsz e1ptpt003" v-if="row.answerStatus !== '답변대기'">
@@ -176,8 +176,6 @@ export default {
 
         this.qnaStore.fetchInquiries().then(() => {
           this.localTableData = this.qnaStore.inquiries;
-          console.log("문의 탭 눌렀을 때 로드되는 것들:", this.localTableData);
-          console.log("로그인된 사람의 email 받아오는 거:", this.userEmail);
         });
       });
     },
@@ -221,8 +219,7 @@ export default {
       el.style.maxHeight = "0px";
     },
     addNewInquiry(newInquiry) {
-      newInquiry.created_at = new Date().toISOString().split("T")[0];
-      this.localTableData.push(newInquiry);
+      newInquiry.email = this.userEmail;  // 로그인된 사용자의 이메일을 새 문의에 추가
       this.closeModal();
     },
     updateInquiry(updatedInquiry) {
@@ -237,9 +234,9 @@ export default {
         this.closeModal();
       }
     },
-    deleteInquiry(index) {
-      // 문의를 삭제할 때, 현재 토글된 인덱스를 초기화
-      this.localTableData.splice(index, 1); // 해당 인덱스의 문의 삭제
+    deleteInquiry(idx, index) {
+      this.qnaStore.deleteInquiry(idx, index);
+
       if (this.expandedInquiryIndex === index) {
         // 삭제된 인덱스가 현재 토글된 인덱스라면 초기화
         this.expandedInquiryIndex = null;

--- a/frontend/src/components/board/BoardDetailNavComponent.vue
+++ b/frontend/src/components/board/BoardDetailNavComponent.vue
@@ -87,12 +87,13 @@
                     <span>{{ row.content }}<br /></span>
                   </div>
                 </div>
-                <div class="css-1j49yxi e11ufodi1" v-if="row.answerStatus !== '답변완료'">
+                <div class="css-1j49yxi e11ufodi1"
+                  v-if="row.answerStatus !== '답변완료' && row.email === this.userEmail">
                   <button type=" button" @click="openEditModal(index)">수정</button>
                   <button type="button" class="css-1ankuif e11ufodi0" @click="deleteInquiry(index)">삭제</button>
                 </div>
               </div>
-              <div class=" css-tnubsz e1ptpt003" v-if="row.answerStatus !== '답변대기'">
+              <div class="css-tnubsz e1ptpt003" v-if="row.answerStatus !== '답변대기'">
                 <div class="css-1n83etr e1ptpt002">
                   <div class="css-m1wgq7 e1ptpt001">
                     <span class="css-1non6l6 ey0f1wv0"></span>
@@ -125,11 +126,15 @@
 import { useQnaStore } from "@/stores/useQnaStore";
 import QnaRegisterModalComponent from "../qna/QnaRegisterModalComponent.vue";
 import { mapStores } from "pinia";
+import { useUserStore } from "@/stores/useUserStore";
 
 export default {
   name: "BoardDetailNavComponent",
   computed: {
-    ...mapStores(useQnaStore),
+    ...mapStores(useQnaStore, useUserStore),
+    userEmail() {
+      return this.userStore.userDetail.email || "email 세팅 안 됨";
+    },
   },
   props: {
     thumbnails: {
@@ -164,8 +169,16 @@ export default {
   methods: {
     loadInquiries() {
       this.activeTab = "inquiries"; // 문의 탭 활성화
-      this.qnaStore.fetchInquiries().then(() => {
-        this.localTableData = this.qnaStore.inquiries;
+
+      this.userStore.getDetail().then(() => {
+        const userEmail = this.userStore.userDetail.email;
+        console.log("로그인된 사용자의 이메일:", userEmail);
+
+        this.qnaStore.fetchInquiries().then(() => {
+          this.localTableData = this.qnaStore.inquiries;
+          console.log("문의 탭 눌렀을 때 로드되는 것들:", this.localTableData);
+          console.log("로그인된 사람의 email 받아오는 거:", this.userEmail);
+        });
       });
     },
     formatDate(dateString) {

--- a/frontend/src/components/qna/QnaRegisterModalComponent.vue
+++ b/frontend/src/components/qna/QnaRegisterModalComponent.vue
@@ -91,6 +91,7 @@
 import axios from 'axios';
 import { useQnaStore } from "@/stores/useQnaStore";
 import { mapStores } from "pinia";
+import { useUserStore } from "@/stores/useUserStore";  // 사용자 스토어 가져오기
 
 export default {
     name: "QnaRegisterModalComponent",
@@ -110,6 +111,10 @@ export default {
         title: {
             type: String,
             required: true
+        },
+        productBoardIdx: {
+            type: Number,
+            required: true,  // 상품 ID가 필수 값
         },
     },
     data() {
@@ -132,7 +137,7 @@ export default {
         isFormValid() {
             return this.subject.trim().length >= 2 && this.content.trim().length >= 5;
         },
-        ...mapStores(useQnaStore),
+        ...mapStores(useQnaStore, useUserStore),
         localTableData() {
             return this.qnaStore.inquiries;
         },
@@ -145,8 +150,8 @@ export default {
             const newInquiry = {
                 title: this.subject,
                 content: this.content,
-                userIdx: 1, // 추후 로그인된 사용자 IDX 사용
-                productBoardIdx: 1, // 추후 해당 게시글 IDX 사용
+                userIdx: this.userStore.userDetail.idx,  // Pinia에서 userStore로부터 userIdx 가져오기
+                productBoardIdx: this.productBoardIdx, // 추후 해당 게시글 IDX 사용
             };
 
             try {
@@ -154,7 +159,7 @@ export default {
 
                 if (response.data.isSuccess) {
                     const registeredInquiry = response.data.result; // 응답으로 받은 데이터를 registeredInquiry에 저장
-
+                    this.qnaStore.addInquiry(registeredInquiry); // 등록된 문의를 스토어에 추가
                     // 부모 컴포넌트에 데이터 전달
                     this.$emit("submit", registeredInquiry);
                     this.closeModal();

--- a/frontend/src/stores/useQnaStore.js
+++ b/frontend/src/stores/useQnaStore.js
@@ -12,6 +12,7 @@ export const useQnaStore = defineStore("qna", {
                 const response = await axios.get('/api/qna/question/list'); // 실제 API URL
                 if (response.data.isSuccess) {
                     this.inquiries = response.data.result;
+                    console.log(this.inquiries);
                 } else {
                     console.error('문의 목록을 불러오는 중 오류 발생:', response.data.message);
                 }

--- a/frontend/src/stores/useQnaStore.js
+++ b/frontend/src/stores/useQnaStore.js
@@ -9,7 +9,7 @@ export const useQnaStore = defineStore("qna", {
     actions: {
         async fetchInquiries() {
             try {
-                const response = await axios.get('/api/qna/question/list'); // 실제 API URL
+                const response = await axios.get('/api/qna/question/list'); 
                 if (response.data.isSuccess) {
                     this.inquiries = response.data.result;
                     console.log(this.inquiries);
@@ -26,8 +26,19 @@ export const useQnaStore = defineStore("qna", {
         updateInquiry(index, updatedInquiry) {
             this.inquiries[index] = { ...this.inquiries[index], ...updatedInquiry };
         },
-        deleteInquiry(index) {
-            this.inquiries.splice(index, 1);
+        async deleteInquiry(idx, index) {
+            try {
+                // console.log('삭제 요청 경로:', `/api/qna/question/delete/${idx}`);
+                const response = await axios.delete(`/api/qna/question/delete/${idx}`);
+                if (response.data.isSuccess) {
+                    this.inquiries.splice(index, 1);  
+                    console.log('문의가 성공적으로 삭제되었습니다.');
+                } else {
+                    console.error('문의 삭제 중 오류 발생:', response.data.message);
+                }
+            } catch (error) {
+                console.error('문의 삭제 중 오류 발생:', error);
+            }
         },
     },
 });


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #189

<br>
 

## 📝 작업 내용

> 백엔드의 문의 삭제 API와 연동하여 화면 기능을 구현했습니다.
- 문의 작성자와 로그인한 사용자가 동일하고, 답변 상태가 "답변대기"일 경우에만 수정/삭제 버튼이 표시되도록 구현

<br>

## **💬 리뷰 요구사항(선택)**

> 일반 회원으로 로그인 후, `/board/detail/1` 경로에서, `backend/feature/user/qna-delete` 브랜치와 함께 실행 후 테스트해주세요.

- [ ] 문의 작성자와 로그인한 사용자가 동일하고, 답변 상태가 답변대기일 때만 수정/삭제 버튼이 표시되는지
- [ ] 선택한 문의의 `삭제`버튼을 눌렀을 때, 화면에서 삭제되고 DB에서도 삭제가 반영되는지
- [ ] 새로 등록된 문의에서 새로고침 없이 `삭제` 버튼을 눌렀을 때 삭제가 정상적으로 작동하는지 확인부탁드려요! :)