### PR TITLE
[#44] 상품 문의 삭제 기능 구현

### DIFF
--- a/backend/src/main/java/org/example/backend/domain/qna/controller/QuestionController.java
+++ b/backend/src/main/java/org/example/backend/domain/qna/controller/QuestionController.java
@@ -66,4 +66,17 @@ public class QuestionController {
         List<QuestionDto.QuestionListResponse> questionList = questionService.getQuestions();
         return new BaseResponse<>(questionList);
     }
+
+    @DeleteMapping("/delete/{id}")
+    public BaseResponse deleteQuestion(@PathVariable Long id, @AuthenticationPrincipal UserDetails userDetails){
+        try{
+            String email = userDetails.getUsername();
+            questionService.deleteQuestion(id, email);
+            return new BaseResponse<>(BaseResponseStatus.SUCCESS);
+        } catch (InvalidCustomException e) {
+            return new BaseResponse<>(e.getStatus());
+        } catch (Exception e) {
+            return new BaseResponse<>(BaseResponseStatus.QNA_QUESTION_DELETE_FAIL);
+        }
+    }
 }

--- a/backend/src/main/java/org/example/backend/domain/qna/controller/QuestionController.java
+++ b/backend/src/main/java/org/example/backend/domain/qna/controller/QuestionController.java
@@ -3,7 +3,6 @@ package org.example.backend.domain.qna.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.backend.domain.qna.model.dto.QuestionDto;
 import org.example.backend.domain.qna.service.QuestionService;
@@ -34,30 +33,22 @@ public class QuestionController {
                             }
                     )
             ))
-
     @PostMapping("/create")
-    public BaseResponse create(@RequestBody QuestionDto.QuestionCreateRequest request, @AuthenticationPrincipal UserDetails userDetails){
-        try{
-            String email = userDetails.getUsername(); // 인증된 사용자의 이메일 가져오기
+    public BaseResponse create(@RequestBody QuestionDto.QuestionCreateRequest request,
+                               @AuthenticationPrincipal UserDetails userDetails) {
+        String email = userDetails.getUsername(); // 인증된 사용자의 이메일 가져오기
 
-            if (request.getTitle() == null || request.getTitle().trim().isEmpty()) {
-                throw new InvalidCustomException(BaseResponseStatus.QNA_QUESTION_FAIL_EMPTY_TITLE);
-            }
-            if (request.getContent() == null || request.getContent().trim().isEmpty()) {
-                throw new InvalidCustomException(BaseResponseStatus.QNA_QUESTION_FAIL_EMPTY_CONTENT);
-            }
-
-            Long productBoardIdx = request.getProductBoardIdx();  // Request Body로 전달받은 productBoardIdx 사용
-
-            // 문의 등록 후 사용자 이름, 날짜, 답변 상태를 함께 응답
-            QuestionDto.QuestionCreateResponse response = questionService.createQuestion(request, email, productBoardIdx);
-            return new BaseResponse<>(response);
-
-        } catch (InvalidCustomException e){
-            return new  BaseResponse<>(e.getStatus());
-        } catch (Exception e){
-            return new BaseResponse<>(BaseResponseStatus.FAIL);
+        if (request.getTitle() == null || request.getTitle().trim().isEmpty()) {
+            throw new InvalidCustomException(BaseResponseStatus.QNA_QUESTION_FAIL_EMPTY_TITLE);
         }
+        if (request.getContent() == null || request.getContent().trim().isEmpty()) {
+            throw new InvalidCustomException(BaseResponseStatus.QNA_QUESTION_FAIL_EMPTY_CONTENT);
+        }
+
+        Long productBoardIdx = request.getProductBoardIdx();  // Request Body로 전달받은 productBoardIdx 사용
+        QuestionDto.QuestionCreateResponse response = questionService.createQuestion(request, email, productBoardIdx);
+
+        return new BaseResponse<>(response);
     }
 
     @Operation(summary = "문의 목록 조회 API", description = "DB에 저장된 문의 목록을 반환합니다.")
@@ -68,15 +59,10 @@ public class QuestionController {
     }
 
     @DeleteMapping("/delete/{id}")
-    public BaseResponse deleteQuestion(@PathVariable Long id, @AuthenticationPrincipal UserDetails userDetails){
-        try{
-            String email = userDetails.getUsername();
-            questionService.deleteQuestion(id, email);
-            return new BaseResponse<>(BaseResponseStatus.SUCCESS);
-        } catch (InvalidCustomException e) {
-            return new BaseResponse<>(e.getStatus());
-        } catch (Exception e) {
-            return new BaseResponse<>(BaseResponseStatus.QNA_QUESTION_DELETE_FAIL);
-        }
+    public BaseResponse deleteQuestion(@PathVariable Long id,
+                                       @AuthenticationPrincipal UserDetails userDetails) {
+        String email = userDetails.getUsername();
+        questionService.deleteQuestion(id, email);
+        return new BaseResponse<>(BaseResponseStatus.SUCCESS);
     }
 }

--- a/backend/src/main/java/org/example/backend/domain/qna/model/dto/QuestionDto.java
+++ b/backend/src/main/java/org/example/backend/domain/qna/model/dto/QuestionDto.java
@@ -44,6 +44,7 @@ public class QuestionDto {
     @AllArgsConstructor
     @NoArgsConstructor
     public static class QuestionCreateResponse{
+        private Long idx;
         private String title;
         private String content;
         private String userName;
@@ -56,10 +57,12 @@ public class QuestionDto {
     @AllArgsConstructor
     @NoArgsConstructor
     public static class QuestionListResponse {
+        private Long idx;
         private String title;
         private String content;
         private String userName;
         private String answerStatus;
         private LocalDateTime createdAt;
+        private String email;
     }
 }

--- a/backend/src/main/java/org/example/backend/domain/qna/model/entity/Question.java
+++ b/backend/src/main/java/org/example/backend/domain/qna/model/entity/Question.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.example.backend.domain.board.model.entity.ProductBoard;
+import org.example.backend.domain.qna.model.dto.QuestionDto;
 import org.example.backend.domain.user.model.entity.User;
 import org.example.backend.global.common.constants.AnswerStatus;
 import org.springframework.data.annotation.CreatedDate;
@@ -48,7 +49,31 @@ public class Question {
     @Column(name = "answer_status")
     private String answerStatus = AnswerStatus.ANSWER_WAITING.getStatus();
 
-    // 답변이 등록 되면 문의 상태를 "답변완료"로 변경하는 메서드
+    public QuestionDto.QuestionListResponse toQuestionListResponse() {
+        return QuestionDto.QuestionListResponse.builder()
+                .idx(this.idx)
+                .title(this.title)
+                .content(this.content)
+                .userName(this.user.getName())
+                .answerStatus(this.answerStatus)
+                .createdAt(this.createdAt)
+                .email(this.user.getEmail())
+                .build();
+    }
+
+    // 새로운 변환 메서드: 문의 생성 응답 DTO로 변환
+    public QuestionDto.QuestionCreateResponse toQuestionCreateResponse() {
+        return QuestionDto.QuestionCreateResponse.builder()
+                .idx(this.idx)
+                .title(this.title)
+                .content(this.content)
+                .userName(this.user.getName())
+                .answerStatus(this.answerStatus)
+                .createdAt(this.createdAt)
+                .build();
+    }
+
+    // 답변이 등록되면 문의 상태를 "답변완료"로 변경하는 메서드
 //    public void markAsAnswered(){
 //        this.answerStatus = AnswerStatus.ANSWER_COMPLETED.getStatus();
 //    }

--- a/backend/src/main/java/org/example/backend/domain/qna/service/QuestionService.java
+++ b/backend/src/main/java/org/example/backend/domain/qna/service/QuestionService.java
@@ -8,6 +8,7 @@ import org.example.backend.domain.qna.model.entity.Question;
 import org.example.backend.domain.qna.repository.QuestionRepository;
 import org.example.backend.domain.user.model.entity.User;
 import org.example.backend.domain.user.repository.UserRepository;
+import org.example.backend.global.common.constants.AnswerStatus;
 import org.example.backend.global.common.constants.BaseResponseStatus;
 import org.example.backend.global.exception.InvalidCustomException;
 import org.springframework.stereotype.Service;
@@ -38,6 +39,7 @@ public class QuestionService {
 
         // 문의 등록 후 사용자 이름, 답변 상태, 등록 날짜 함께 반환
         return QuestionDto.QuestionCreateResponse.builder()
+                .idx(question.getIdx())
                 .title(question.getTitle())
                 .content(question.getContent())
                 .userName(user.getName())  // 사용자 이름 반환
@@ -48,12 +50,31 @@ public class QuestionService {
     public List<QuestionDto.QuestionListResponse> getQuestions() {
         return questionRepository.findAll().stream()
                 .map(question -> QuestionDto.QuestionListResponse.builder()
+                        .idx(question.getIdx())
                         .title(question.getTitle())
                         .content(question.getContent())
                         .userName(question.getUser().getName())  // 사용자 이름
                         .answerStatus(question.getAnswerStatus())  // 답변 상태
                         .createdAt(question.getCreatedAt())  // 생성일
+                        .email(question.getUser().getEmail())
                         .build())
                 .collect(Collectors.toList());
+    }
+    public void deleteQuestion(Long questionId, String email){
+        Question question = questionRepository.findById(questionId)
+                .orElseThrow(() -> new InvalidCustomException(BaseResponseStatus.QNA_ANSWER_DELETE_FAIL_NOT_FOUND));
+
+        // 문의 작성자와 로그인된 사용자의 이메일이 동일한지 확인
+        if (!question.getUser().getEmail().equals(email)) {
+            throw new InvalidCustomException(BaseResponseStatus.FAIL_UNAUTHORIZED);
+        }
+
+        // 답변 상태가 "답변대기"인지 확인
+        if (!question.getAnswerStatus().equals(AnswerStatus.ANSWER_WAITING.getStatus())) {
+            throw new InvalidCustomException(BaseResponseStatus.QNA_ANSWER_DELETE_FAIL);
+        }
+
+        // 삭제 처리
+        questionRepository.delete(question);
     }
 }

--- a/backend/src/main/java/org/example/backend/domain/qna/service/QuestionService.java
+++ b/backend/src/main/java/org/example/backend/domain/qna/service/QuestionService.java
@@ -37,30 +37,17 @@ public class QuestionService {
         Question question = request.toEntity(user, productBoard);
         questionRepository.save(question);
 
-        // 문의 등록 후 사용자 이름, 답변 상태, 등록 날짜 함께 반환
-        return QuestionDto.QuestionCreateResponse.builder()
-                .idx(question.getIdx())
-                .title(question.getTitle())
-                .content(question.getContent())
-                .userName(user.getName())  // 사용자 이름 반환
-                .answerStatus(question.getAnswerStatus())  // 답변 상태 반환
-                .createdAt(question.getCreatedAt())  // 생성 날짜 반환
-                .build();
+        // 엔티티의 변환 메서드를 호출하여 DTO 반환
+        return question.toQuestionCreateResponse();
     }
+
     public List<QuestionDto.QuestionListResponse> getQuestions() {
         return questionRepository.findAll().stream()
-                .map(question -> QuestionDto.QuestionListResponse.builder()
-                        .idx(question.getIdx())
-                        .title(question.getTitle())
-                        .content(question.getContent())
-                        .userName(question.getUser().getName())  // 사용자 이름
-                        .answerStatus(question.getAnswerStatus())  // 답변 상태
-                        .createdAt(question.getCreatedAt())  // 생성일
-                        .email(question.getUser().getEmail())
-                        .build())
+                .map(Question::toQuestionListResponse)  // 엔티티의 변환 메서드 사용
                 .collect(Collectors.toList());
     }
-    public void deleteQuestion(Long questionId, String email){
+
+    public void deleteQuestion(Long questionId, String email) {
         Question question = questionRepository.findById(questionId)
                 .orElseThrow(() -> new InvalidCustomException(BaseResponseStatus.QNA_ANSWER_DELETE_FAIL_NOT_FOUND));
 

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -85,7 +85,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #44

<br>
 

## 📝 작업 내용

> 문의 삭제 API를 구현했습니다.
- 문의 작성자와 로그인한 사용자가 동일한 경우에만, 그리고 답변 상태가 답변대기일 때만 삭제 기능이 가능하도록 처리
- 삭제 요청 시 DB에서 해당 문의가 정상적으로 삭제되도록 API를 구현
<br>

## **💬 리뷰 요구사항(선택)**

> 일반회원으로 로그인 후, `/board/detail/1` 경로에서, `frontend/feature/user/qna-delete` 브랜치와 함께 실행 후 테스트해주세요.
- [ ] 문의 작성자와 로그인한 사용자가 동일하고, 답변 상태가 답변대기일 때만 수정/삭제 버튼이 표시되는지
- [ ] 선택한 문의의 `삭제`버튼을 눌렀을 때, 화면에서 삭제되고 DB에서도 삭제가 반영되는지
- [ ] 새로 등록된 문의에서 새로고침 없이 `삭제` 버튼을 눌렀을 때 삭제가 정상적으로 작동하는지 확인부탁드려요! :)
