### PR TITLE
[#87,#89] 마이페이지 주문 내역, 상세 기능 구현

### DIFF
--- a/frontend/src/components/company/OrderListCardComponent.vue
+++ b/frontend/src/components/company/OrderListCardComponent.vue
@@ -21,19 +21,21 @@
 
               <dl>
                 <dt>결제금액</dt>
-                <dd>13,560원</dd>
+                <dd>{{ data.totalPaidAmount }}원</dd>
               </dl>
             </div>
 
             <div class="desc" style="margin-left: 50px">
               <dl>
                 <dt>주문자명</dt>
-                <dd>심키즈</dd>
+                <dd>{{ data.ordererName }}</dd>
               </dl>
 
               <dl>
                 <dt>주문방법</dt>
-                <dd>{{ data.payMethod }}</dd>
+                <dd>
+                  {{ data.payMethod == "kakaopay" ? "카카오페이" : "토스페이" }}
+                </dd>
               </dl>
             </div>
           </div>

--- a/frontend/src/components/mypage/MypageOrderComponent.vue
+++ b/frontend/src/components/mypage/MypageOrderComponent.vue
@@ -6,16 +6,13 @@
           <div class="css-2kmie e1g49j8k1">
             <div class="css-peeqro e190ng8o1">
               <div class="css-jyp95e e1l5ke4x0">
-                <button @click="toggleDetails" class="css-7sy6n e1rmfz7b0">
+                <button @click="showOrderDetail" class="css-7sy6n e1rmfz7b0">
                   <img
                     src="@/assets/arrow.png"
                     alt="icon"
                     width="40"
                     height="40"
-                    :style="{
-                      transform: arrowRotate,
-                      transition: 'transform 0.3s',
-                    }"
+                    style="transition: 'transform 0.3s'"
                   />
                 </button>
                 <div class="css-7uztss e1rmfz7b4">
@@ -23,13 +20,13 @@
                     <p
                       class="_97oqoup _97oqouv _97oqou5 ldmw177c _97oqou19 _97oqouj ldmw177q _97oqou12 _97oqouc ldmw177j css-wcc2f6 e1rmfz7b3"
                     >
-                      2024.09.05
+                      {{ formattedDate(order.createdAt) }}
                     </p>
                     <div class="css-k7chvl e1rmfz7b1">
                       <p
                         class="_97oqoup _97oqoux _97oqou7 ldmw177a _97oqou1b _97oqoul ldmw177s _97oqou13 _97oqoud ldmw177i css-1vgapaa e1rmfz7b2"
                       >
-                        주문번호 2307216320130
+                        주문번호 {{ order.ordersNumber }}
                       </p>
                     </div>
                   </div>
@@ -44,7 +41,7 @@
                     <p
                       class="_97oqoup _97oqouv _97oqou5 ldmw177c _97oqou19 _97oqouj ldmw177q _97oqou12 _97oqouc ldmw177j css-1n1zmlq e1xhbacy1"
                     >
-                      주문완료
+                      {{ order.status }}
                     </p>
                   </div>
                 </div>
@@ -62,7 +59,7 @@
                         <p
                           class="_97oqoup _97oqouw _97oqou6 ldmw177b _97oqou1a _97oqouk ldmw177r _97oqou13 _97oqoud ldmw177i css-1dl78ek e73mjag3"
                         >
-                          [정기배송] 한 끼 보리샐러드
+                          {{ order.title }}
                         </p>
                       </a>
                       <div class="css-1tf2711 e73mjag8">
@@ -100,15 +97,23 @@ export default {
       arrowRotated: false,
     };
   },
-  computed: {
-    arrowRotate() {
-      return this.arrowRotated ? "rotate(90deg)" : "rotate(0deg)";
+  props: {
+    order: {
+      type: Object,
+      required: true,
     },
   },
   methods: {
-    toggleDetails() {
-      this.isDetailsVisible = !this.isDetailsVisible;
-      this.arrowRotated = !this.arrowRotated;
+    showOrderDetail() {
+      this.$router.push({ path: `/mypage/order/${this.order.orderIdx}` });
+    },
+    formattedDate(dateString) {
+      const date = new Date(dateString);
+      const year = date.getFullYear();
+      const month = ("0" + (date.getMonth() + 1)).slice(-2);
+      const day = ("0" + date.getDate()).slice(-2);
+
+      return `${year}.${month}.${day}`;
     },
   },
 };

--- a/frontend/src/components/mypage/MypageOrderComponent.vue
+++ b/frontend/src/components/mypage/MypageOrderComponent.vue
@@ -66,9 +66,16 @@
                         <p
                           class="_97oqoup _97oqouw _97oqou6 ldmw177b _97oqou1a _97oqouk ldmw177r _97oqou11 _97oqoub ldmw177k css-1dl78ek e73mjag4"
                         >
-                          89,900원
+                          {{
+                            Math.round(
+                              order.minimumPrice *
+                                (1 - order.discountRate / 100)
+                            ).toLocaleString()
+                          }}원
                         </p>
-                        <p class="css-if5wh3 e73mjag1">145,000원</p>
+                        <p class="css-if5wh3 e73mjag1">
+                          {{ order.minimumPrice.toLocaleString() }}원
+                        </p>
                         <div
                           width="1px"
                           height="10px"

--- a/frontend/src/components/mypage/MypageOrderComponent.vue
+++ b/frontend/src/components/mypage/MypageOrderComponent.vue
@@ -49,8 +49,7 @@
                   <div class="css-1tf2711 e73mjag8">
                     <a href="/goods/5054274" class="css-1ll9bqd e73mjag0">
                       <img
-                        src="https://img-cf.kurly.com/hdims/resize/%5E%3E120x%3E156/cropcenter/120x156/quality/85/src/shop/data/goods/1594097581645l0.jpg"
-                        alt="[정기배송] 한 끼 보리샐러드"
+                        :src="order.thumnailUrl"
                         class="css-13pph03 e73mjag7"
                       />
                     </a>

--- a/frontend/src/components/mypage/MypageOrderComponent.vue
+++ b/frontend/src/components/mypage/MypageOrderComponent.vue
@@ -1,137 +1,114 @@
 <template>
-  <div class="css-heioij eug5r8l1">
-    <div
-      @click="goToOrderDetail(order.orderIdx)"
-      v-for="order in orderList"
-      :key="order.id"
-      class="order-item"
-    >
-      <MypageOrderComponent />
-    </div>
-
-    <div class="css-rdz8z7 e82lnfz1">
-      <a class="page-unselected e82lnfz0" @click="goToPage(1)"
-        ><img
-          src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAkAAAAHCAQAAABwkq/rAAAAHUlEQVR42mNgAIPi/8X/kWkwA8SE0UQIMJAsCKMBBzk27fqtkcYAAAAASUVORK5CYII="
-          alt="처음 페이지로 이동하기 아이콘" /></a
-      ><a class="page-unselected e82lnfz0" @click="prevPageGroup"
-        ><img
-          src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAHCAQAAABqrk9lAAAAGElEQVR42mNgAIPi/8X/4QwwE5PBQJADAAKSG3cyVhtXAAAAAElFTkSuQmCC"
-          alt="이전 페이지로 이동하기 아이콘"
-      /></a>
-
-      <a
-        v-for="pageNumber in visiblePages"
-        :key="pageNumber"
-        :class="
-          pageNumber === currentPage
-            ? 'page-selected e82lnfz0'
-            : 'page-unselected e82lnfz0'
-        "
-        @click="goToPage(pageNumber)"
-      >
-        {{ pageNumber }}
-      </a>
-
-      <a class="page-unselected e82lnfz0" @click="nextPageGroup"
-        ><img
-          src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAHCAQAAABqrk9lAAAAGUlEQVR42mMo/l/8nwECQEwCHEwGhAlRBgA2mht3SwgzrwAAAABJRU5ErkJggg=="
-          alt="다음 페이지로 이동하기 아이콘" /></a
-      ><a class="page-unselected e82lnfz0" @click="goToPage(totalPages)"
-        ><img
-          src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAkAAAAHCAQAAABwkq/rAAAAIElEQVR42mMo/l/8n4GBgQFGQ5kgDowmQZCwAMImhDkAb0k27Zcisn8AAAAASUVORK5CYII="
-          alt="마지막 페이지로 이동하기 아이콘"
-      /></a>
+  <div>
+    <div class="css-1xdhyk6 eug5r8l0">
+      <div class="css-10ekv2i e13vhfr40">
+        <div class="css-1phmj5u e190ng8o0">
+          <div class="css-2kmie e1g49j8k1">
+            <div class="css-peeqro e190ng8o1">
+              <div class="css-jyp95e e1l5ke4x0">
+                <button @click="toggleDetails" class="css-7sy6n e1rmfz7b0">
+                  <img
+                    src="@/assets/arrow.png"
+                    alt="icon"
+                    width="40"
+                    height="40"
+                    :style="{
+                      transform: arrowRotate,
+                      transition: 'transform 0.3s',
+                    }"
+                  />
+                </button>
+                <div class="css-7uztss e1rmfz7b4">
+                  <div>
+                    <p
+                      class="_97oqoup _97oqouv _97oqou5 ldmw177c _97oqou19 _97oqouj ldmw177q _97oqou12 _97oqouc ldmw177j css-wcc2f6 e1rmfz7b3"
+                    >
+                      2024.09.05
+                    </p>
+                    <div class="css-k7chvl e1rmfz7b1">
+                      <p
+                        class="_97oqoup _97oqoux _97oqou7 ldmw177a _97oqou1b _97oqoul ldmw177s _97oqou13 _97oqoud ldmw177i css-1vgapaa e1rmfz7b2"
+                      >
+                        주문번호 2307216320130
+                      </p>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  height="1px"
+                  width="100%"
+                  class="css-yng2ii e1ypu1ln0"
+                ></div>
+                <div class="css-1t4yb7q e1xhbacy2">
+                  <div class="css-wnosz2 e1xhbacy0">
+                    <p
+                      class="_97oqoup _97oqouv _97oqou5 ldmw177c _97oqou19 _97oqouj ldmw177q _97oqou12 _97oqouc ldmw177j css-1n1zmlq e1xhbacy1"
+                    >
+                      주문완료
+                    </p>
+                  </div>
+                </div>
+                <div class="css-vts8bc e9fxgjh2">
+                  <div class="css-1tf2711 e73mjag8">
+                    <a href="/goods/5054274" class="css-1ll9bqd e73mjag0">
+                      <img
+                        src="https://img-cf.kurly.com/hdims/resize/%5E%3E120x%3E156/cropcenter/120x156/quality/85/src/shop/data/goods/1594097581645l0.jpg"
+                        alt="[정기배송] 한 끼 보리샐러드"
+                        class="css-13pph03 e73mjag7"
+                      />
+                    </a>
+                    <div class="_17g6wc40">
+                      <a href="/goods/5054274" class="css-1ll9bqd e73mjag0">
+                        <p
+                          class="_97oqoup _97oqouw _97oqou6 ldmw177b _97oqou1a _97oqouk ldmw177r _97oqou13 _97oqoud ldmw177i css-1dl78ek e73mjag3"
+                        >
+                          [정기배송] 한 끼 보리샐러드
+                        </p>
+                      </a>
+                      <div class="css-1tf2711 e73mjag8">
+                        <p
+                          class="_97oqoup _97oqouw _97oqou6 ldmw177b _97oqou1a _97oqouk ldmw177r _97oqou11 _97oqoub ldmw177k css-1dl78ek e73mjag4"
+                        >
+                          89,900원
+                        </p>
+                        <p class="css-if5wh3 e73mjag1">145,000원</p>
+                        <div
+                          width="1px"
+                          height="10px"
+                          class="css-9ib26w e1ypu1ln0"
+                        ></div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div class="css-8vtrb0 eus1fbt1"></div>
+              </div>
+            </div>
+          </div>
+          <div class="css-21ijkk e190ng8o3"></div>
+        </div>
+      </div>
     </div>
   </div>
 </template>
 
 <script>
-import MypageOrderComponent from "@/components/mypage/MypageOrderComponent.vue";
-import { mapStores } from "pinia";
-import { useOrderStore } from "@/stores/useOrderStore.js";
-
 export default {
   data() {
     return {
-      orderList: [],
-      pagesPerGroup: 5,
-      totalPages: 1,
+      isDetailsVisible: false,
+      arrowRotated: false,
     };
   },
-  components: {
-    MypageOrderComponent,
-  },
-
-  created() {
-    this.setOrderList();
-  },
   computed: {
-    ...mapStores(useOrderStore),
-    currentPage() {
-      return Number(this.$route.query.page) || 1;
+    arrowRotate() {
+      return this.arrowRotated ? "rotate(90deg)" : "rotate(0deg)";
     },
-    // 시작 페이지 번호 계산
-    startPage() {
-      return (
-        Math.floor((this.currentPage - 1) / this.pagesPerGroup) *
-          this.pagesPerGroup +
-        1
-      );
-    },
-    // 끝 페이지 번호 계산
-    endPage() {
-      return Math.min(this.startPage + this.pagesPerGroup - 1, this.totalPages);
-    },
-    // 현재 보여질 페이지 번호 목록
-    visiblePages() {
-      const pageNumbers = [];
-      for (let i = this.startPage; i <= this.endPage; i++) {
-        pageNumbers.push(i);
-      }
-      return pageNumbers;
-    },
-  },
-  watch: {
-    "$route.query.page": "setBoards",
-    "$route.query.dateRange": "setBoards",
-    "$route.query.orderStatus": "setBoards",
   },
   methods: {
-    async setOrderList() {
-      const response = await this.orderStore.getUserOrderListWithOption(
-        this.currentPage
-      );
-      this.orderList = response.content;
-      this.totalPages = response.totalPages;
-      console.log(response);
-    },
-    goToPage(pageNumber) {
-      if (pageNumber >= 1 && pageNumber <= this.totalPages) {
-        this.$router.push({
-          query: {
-            page: pageNumber,
-            dateRange: this.selectedDateRange,
-            orderStatus: this.selectedOrderStatus,
-          },
-        });
-      } else if (pageNumber < 1) {
-        alert("첫 번째 페이지입니다.");
-      } else {
-        alert("마지막 페이지입니다.");
-      }
-    },
-    prevPageGroup() {
-      const newPage = this.startPage - 1;
-      this.goToPage(newPage);
-    },
-    nextPageGroup() {
-      const newPage = this.endPage + 1;
-      this.goToPage(newPage);
-    },
-
-    goToOrderDetail(orderId) {
-      this.$router.push({ path: `/mypage/order/${orderId}` });
+    toggleDetails() {
+      this.isDetailsVisible = !this.isDetailsVisible;
+      this.arrowRotated = !this.arrowRotated;
     },
   },
 };
@@ -217,10 +194,6 @@ html {
   justify-content: space-between;
   margin: 0px 20px;
   padding: 25px 0px 20px;
-}
-
-.order-item {
-  margin-bottom: 10px;
 }
 
 .css-eq7f8j {
@@ -1091,52 +1064,5 @@ textarea {
   justify-content: center;
   cursor: pointer;
   border-width: 0;
-}
-
-.css-rdz8z7 {
-  display: flex;
-  -webkit-box-pack: center;
-  justify-content: center;
-  -webkit-box-align: center;
-  align-items: center;
-  margin-top: 20px;
-}
-
-.page-unselected:first-of-type {
-  border-left: 1px solid rgb(221, 221, 221);
-}
-
-.page-unselected {
-  display: flex;
-  -webkit-box-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  justify-content: center;
-  width: 34px;
-  height: 34px;
-  border-top: 1px solid rgb(221, 221, 221);
-  border-right: 1px solid rgb(221, 221, 221);
-  border-bottom: 1px solid rgb(221, 221, 221);
-  border-image: initial;
-  border-left: none;
-  cursor: pointer;
-}
-
-.page-selected {
-  display: flex;
-  -webkit-box-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  justify-content: center;
-  width: 34px;
-  height: 34px;
-  border-top: 1px solid rgb(221, 221, 221);
-  border-right: 1px solid rgb(221, 221, 221);
-  border-bottom: 1px solid rgb(221, 221, 221);
-  border-image: initial;
-  border-left: none;
-  cursor: pointer;
-  background-color: rgb(247, 247, 247);
-  color: rgb(95, 0, 128);
 }
 </style>

--- a/frontend/src/components/mypage/MypageOrderDetailComponent.vue
+++ b/frontend/src/components/mypage/MypageOrderDetailComponent.vue
@@ -1,137 +1,192 @@
 <template>
-  <div class="css-heioij eug5r8l1">
-    <div
-      @click="goToOrderDetail(order.orderIdx)"
-      v-for="order in orderList"
-      :key="order.id"
-      class="order-item"
-    >
-      <MypageOrderComponent />
-    </div>
-
-    <div class="css-rdz8z7 e82lnfz1">
-      <a class="page-unselected e82lnfz0" @click="goToPage(1)"
-        ><img
-          src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAkAAAAHCAQAAABwkq/rAAAAHUlEQVR42mNgAIPi/8X/kWkwA8SE0UQIMJAsCKMBBzk27fqtkcYAAAAASUVORK5CYII="
-          alt="처음 페이지로 이동하기 아이콘" /></a
-      ><a class="page-unselected e82lnfz0" @click="prevPageGroup"
-        ><img
-          src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAHCAQAAABqrk9lAAAAGElEQVR42mNgAIPi/8X/4QwwE5PBQJADAAKSG3cyVhtXAAAAAElFTkSuQmCC"
-          alt="이전 페이지로 이동하기 아이콘"
-      /></a>
-
-      <a
-        v-for="pageNumber in visiblePages"
-        :key="pageNumber"
-        :class="
-          pageNumber === currentPage
-            ? 'page-selected e82lnfz0'
-            : 'page-unselected e82lnfz0'
-        "
-        @click="goToPage(pageNumber)"
-      >
-        {{ pageNumber }}
-      </a>
-
-      <a class="page-unselected e82lnfz0" @click="nextPageGroup"
-        ><img
-          src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAHCAQAAABqrk9lAAAAGUlEQVR42mMo/l/8nwECQEwCHEwGhAlRBgA2mht3SwgzrwAAAABJRU5ErkJggg=="
-          alt="다음 페이지로 이동하기 아이콘" /></a
-      ><a class="page-unselected e82lnfz0" @click="goToPage(totalPages)"
-        ><img
-          src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAkAAAAHCAQAAABwkq/rAAAAIElEQVR42mMo/l/8n4GBgQFGQ5kgDowmQZCwAMImhDkAb0k27Zcisn8AAAAASUVORK5CYII="
-          alt="마지막 페이지로 이동하기 아이콘"
-      /></a>
+  <div>
+    <div class="css-3dze2x eug5r8l1" id="details">
+      <button class="css-f848a6 e2jhvp32">
+        <p
+          class="_97oqoup _97oqouu _97oqou4 ldmw177d _97oqou18 _97oqoui ldmw177p _97oqou12 _97oqouc ldmw177j css-1dl78ek e2jhvp31"
+        >
+          주문정보
+        </p>
+      </button>
+      <div class="css-d3v9zr e14m4ys50" style="opacity: 1; height: auto">
+        <div class="css-1a0zxau e1ckt0s50">
+          <div class="css-1aim50k e93c1qv0">
+            <p
+              class="_97oqoup _97oqouw _97oqou6 ldmw177b _97oqou1a _97oqouk ldmw177r _97oqou12 _97oqouc ldmw177j"
+            >
+              주문번호
+            </p>
+            <p
+              class="_97oqoup _97oqouw _97oqou6 ldmw177b _97oqou1a _97oqouk ldmw177r _97oqou12 _97oqouc ldmw177j"
+            >
+              2307216320130
+            </p>
+          </div>
+          <div class="css-1aim50k e2upnqp1">
+            <p
+              class="_97oqoup _97oqouw _97oqou6 ldmw177b _97oqou1a _97oqouk ldmw177r _97oqou13 _97oqoud ldmw177i css-15bah7q e2upnqp0"
+            >
+              결제 일시
+            </p>
+            <div class="css-8yre18 e2upnqp1">
+              <p
+                class="_97oqoup _97oqouw _97oqou6 ldmw177b _97oqou1a _97oqouk ldmw177r _97oqou13 _97oqoud ldmw177i css-uwqhso e2upnqp0"
+              >
+                2024.09.05 16:33:45
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <button class="css-f848a6 e2jhvp32">
+        <p
+          class="_97oqoup _97oqouu _97oqou4 ldmw177d _97oqou18 _97oqoui ldmw177p _97oqou12 _97oqouc ldmw177j css-1dl78ek e2jhvp31"
+        >
+          결제정보
+        </p>
+      </button>
+      <div class="css-d3v9zr e14m4ys50" style="opacity: 1; height: auto">
+        <div class="css-1a0zxau e13968o84">
+          <div class="css-1aim50k e93c1qv0">
+            <p
+              class="_97oqoup _97oqouw _97oqou6 ldmw177b _97oqou1a _97oqouk ldmw177r _97oqou12 _97oqouc ldmw177j"
+            >
+              상품금액
+            </p>
+            <p
+              class="_97oqoup _97oqouw _97oqou6 ldmw177b _97oqou1a _97oqouk ldmw177r _97oqou12 _97oqouc ldmw177j"
+            >
+              145,000원
+            </p>
+          </div>
+          <div class="css-1aim50k e2upnqp1">
+            <p
+              class="_97oqoup _97oqouw _97oqou6 ldmw177b _97oqou1a _97oqouk ldmw177r _97oqou13 _97oqoud ldmw177i css-15bah7q e2upnqp0"
+            >
+              상품할인금액
+            </p>
+            <div class="css-8yre18 e2upnqp1">
+              <p
+                class="_97oqoup _97oqouw _97oqou6 ldmw177b _97oqou1a _97oqouk ldmw177r _97oqou13 _97oqoud ldmw177i css-uwqhso e2upnqp0"
+              >
+                -55,100원
+              </p>
+            </div>
+          </div>
+          <div class="css-1aim50k e2upnqp1">
+            <p
+              class="_97oqoup _97oqouw _97oqou6 ldmw177b _97oqou1a _97oqouk ldmw177r _97oqou13 _97oqoud ldmw177i css-15bah7q e2upnqp0"
+            >
+              포인트
+            </p>
+            <div class="css-8yre18 e2upnqp1">
+              <p
+                class="_97oqoup _97oqouw _97oqou6 ldmw177b _97oqou1a _97oqouk ldmw177r _97oqou13 _97oqoud ldmw177i css-uwqhso e2upnqp0"
+              >
+                -2,000원
+              </p>
+            </div>
+          </div>
+          <div class="css-1aim50k e2upnqp1">
+            <p
+              class="_97oqoup _97oqouw _97oqou6 ldmw177b _97oqou1a _97oqouk ldmw177r _97oqou13 _97oqoud ldmw177i css-15bah7q e2upnqp0"
+            >
+              결제방법
+            </p>
+            <div class="css-8yre18 e2upnqp1">
+              <p
+                class="_97oqoup _97oqouw _97oqou6 ldmw177b _97oqou1a _97oqouk ldmw177r _97oqou13 _97oqoud ldmw177i css-uwqhso e2upnqp0"
+              >
+                카카오페이
+              </p>
+            </div>
+          </div>
+          <div class="css-1aim50k e2upnqp1">
+            <p
+              class="_97oqoup _97oqouw _97oqou6 ldmw177b _97oqou1a _97oqouk ldmw177r _97oqou12 _97oqouc ldmw177j"
+            >
+              총 결제금액
+            </p>
+            <div class="css-8yre18 e2upnqp1">
+              <p
+                class="_97oqoup _97oqouw _97oqou6 ldmw177b _97oqou1a _97oqouk ldmw177r _97oqou12 _97oqouc ldmw177j"
+              >
+                90,900원
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <button class="css-f848a6 e2jhvp32">
+        <p
+          class="_97oqoup _97oqouu _97oqou4 ldmw177d _97oqou18 _97oqoui ldmw177p _97oqou12 _97oqouc ldmw177j css-1dl78ek e2jhvp31"
+        >
+          배송정보
+        </p>
+      </button>
+      <div class="css-d3v9zr e14m4ys50" style="opacity: 1; height: auto">
+        <div class="css-6z4447 e1n2ou003">
+          <p
+            class="_97oqoup _97oqouv _97oqou5 ldmw177c _97oqou19 _97oqouj ldmw177q _97oqou12 _97oqouc ldmw177j css-luewyl e1n2ou001"
+          >
+            심키즈
+          </p>
+          <p
+            class="_97oqoup _97oqouw _97oqou6 ldmw177b _97oqou1a _97oqouk ldmw177r _97oqou13 _97oqoud ldmw177i css-4qwok1 e1n2ou001"
+          >
+            010-1234-****
+          </p>
+          <p
+            class="_97oqoup _97oqouw _97oqou6 ldmw177b _97oqou1a _97oqouk ldmw177r _97oqou13 _97oqoud ldmw177i css-303o8l e1n2ou001"
+          >
+            서울특별시 광진구 군자로0길 50-2
+          </p>
+        </div>
+      </div>
+      <div class="css-od0sqq ecvmg6w3">
+        <p
+          class="_97oqoup _97oqoux _97oqou7 ldmw177a _97oqou1b _97oqoul ldmw177s _97oqou13 _97oqoud ldmw177i css-1fdfbqy ecvmg6w1"
+        >
+          주문취소는 [주문완료] 상태일 경우에만 가능합니다.
+        </p>
+        <p
+          class="_97oqoup _97oqoux _97oqou7 ldmw177a _97oqou1b _97oqoul ldmw177s _97oqou13 _97oqoud ldmw177i css-1fdfbqy ecvmg6w1"
+        >
+          단, 일부 상품의 경우 [주문완료] 상태이더라도 상품의 특성상 주문취소가
+          불가능할 수 있습니다.
+        </p>
+        <button
+          disabled
+          class="tew5wjw tew5wj0 ldmw1780 tew5wjy tew5wj19 tew5wj1b tew5wj14 tew5wj3 ldmw1717i ldmw17183 ldmw1715v ldmw177b tew5wj17 tew5wj1c tew5wj5 ldmw177j tew5wj1l tew5wje ldmw17y6 ldmw17ok ldmw178w tew5wjp ldmw171du css-jz9jxv ecvmg6w2"
+        >
+          <p
+            class="_97oqoup _97oqouw _97oqou6 ldmw177b _97oqou1a _97oqouk ldmw177r _97oqou12 _97oqouc ldmw177j"
+          >
+            주문 취소
+          </p>
+        </button>
+      </div>
     </div>
   </div>
 </template>
 
 <script>
-import MypageOrderComponent from "@/components/mypage/MypageOrderComponent.vue";
-import { mapStores } from "pinia";
-import { useOrderStore } from "@/stores/useOrderStore.js";
-
 export default {
   data() {
     return {
-      orderList: [],
-      pagesPerGroup: 5,
-      totalPages: 1,
+      isDetailsVisible: true,
+      arrowRotated: false,
     };
   },
-  components: {
-    MypageOrderComponent,
-  },
-
-  created() {
-    this.setOrderList();
-  },
   computed: {
-    ...mapStores(useOrderStore),
-    currentPage() {
-      return Number(this.$route.query.page) || 1;
+    arrowRotate() {
+      return this.arrowRotated ? "rotate(90deg)" : "rotate(0deg)";
     },
-    // 시작 페이지 번호 계산
-    startPage() {
-      return (
-        Math.floor((this.currentPage - 1) / this.pagesPerGroup) *
-          this.pagesPerGroup +
-        1
-      );
-    },
-    // 끝 페이지 번호 계산
-    endPage() {
-      return Math.min(this.startPage + this.pagesPerGroup - 1, this.totalPages);
-    },
-    // 현재 보여질 페이지 번호 목록
-    visiblePages() {
-      const pageNumbers = [];
-      for (let i = this.startPage; i <= this.endPage; i++) {
-        pageNumbers.push(i);
-      }
-      return pageNumbers;
-    },
-  },
-  watch: {
-    "$route.query.page": "setBoards",
-    "$route.query.dateRange": "setBoards",
-    "$route.query.orderStatus": "setBoards",
   },
   methods: {
-    async setOrderList() {
-      const response = await this.orderStore.getUserOrderListWithOption(
-        this.currentPage
-      );
-      this.orderList = response.content;
-      this.totalPages = response.totalPages;
-      console.log(response);
-    },
-    goToPage(pageNumber) {
-      if (pageNumber >= 1 && pageNumber <= this.totalPages) {
-        this.$router.push({
-          query: {
-            page: pageNumber,
-            dateRange: this.selectedDateRange,
-            orderStatus: this.selectedOrderStatus,
-          },
-        });
-      } else if (pageNumber < 1) {
-        alert("첫 번째 페이지입니다.");
-      } else {
-        alert("마지막 페이지입니다.");
-      }
-    },
-    prevPageGroup() {
-      const newPage = this.startPage - 1;
-      this.goToPage(newPage);
-    },
-    nextPageGroup() {
-      const newPage = this.endPage + 1;
-      this.goToPage(newPage);
-    },
-
-    goToOrderDetail(orderId) {
-      this.$router.push({ path: `/mypage/order/${orderId}` });
+    toggleDetails() {
+      this.isDetailsVisible = !this.isDetailsVisible;
+      this.arrowRotated = !this.arrowRotated;
     },
   },
 };
@@ -217,10 +272,6 @@ html {
   justify-content: space-between;
   margin: 0px 20px;
   padding: 25px 0px 20px;
-}
-
-.order-item {
-  margin-bottom: 10px;
 }
 
 .css-eq7f8j {
@@ -1091,52 +1142,5 @@ textarea {
   justify-content: center;
   cursor: pointer;
   border-width: 0;
-}
-
-.css-rdz8z7 {
-  display: flex;
-  -webkit-box-pack: center;
-  justify-content: center;
-  -webkit-box-align: center;
-  align-items: center;
-  margin-top: 20px;
-}
-
-.page-unselected:first-of-type {
-  border-left: 1px solid rgb(221, 221, 221);
-}
-
-.page-unselected {
-  display: flex;
-  -webkit-box-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  justify-content: center;
-  width: 34px;
-  height: 34px;
-  border-top: 1px solid rgb(221, 221, 221);
-  border-right: 1px solid rgb(221, 221, 221);
-  border-bottom: 1px solid rgb(221, 221, 221);
-  border-image: initial;
-  border-left: none;
-  cursor: pointer;
-}
-
-.page-selected {
-  display: flex;
-  -webkit-box-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  justify-content: center;
-  width: 34px;
-  height: 34px;
-  border-top: 1px solid rgb(221, 221, 221);
-  border-right: 1px solid rgb(221, 221, 221);
-  border-bottom: 1px solid rgb(221, 221, 221);
-  border-image: initial;
-  border-left: none;
-  cursor: pointer;
-  background-color: rgb(247, 247, 247);
-  color: rgb(95, 0, 128);
 }
 </style>

--- a/frontend/src/components/mypage/MypageOrderDetailComponent.vue
+++ b/frontend/src/components/mypage/MypageOrderDetailComponent.vue
@@ -19,7 +19,7 @@
             <p
               class="_97oqoup _97oqouw _97oqou6 ldmw177b _97oqou1a _97oqouk ldmw177r _97oqou12 _97oqouc ldmw177j"
             >
-              2307216320130
+              {{ order.ordersNumber }}
             </p>
           </div>
           <div class="css-1aim50k e2upnqp1">
@@ -32,7 +32,7 @@
               <p
                 class="_97oqoup _97oqouw _97oqou6 ldmw177b _97oqou1a _97oqouk ldmw177r _97oqou13 _97oqoud ldmw177i css-uwqhso e2upnqp0"
               >
-                2024.09.05 16:33:45
+                {{ formattedDate(order.createdAt) }}
               </p>
             </div>
           </div>
@@ -83,7 +83,7 @@
               <p
                 class="_97oqoup _97oqouw _97oqou6 ldmw177b _97oqou1a _97oqouk ldmw177r _97oqou13 _97oqoud ldmw177i css-uwqhso e2upnqp0"
               >
-                -2,000원
+                -{{ order.usedPoint }}원
               </p>
             </div>
           </div>
@@ -97,7 +97,7 @@
               <p
                 class="_97oqoup _97oqouw _97oqou6 ldmw177b _97oqou1a _97oqouk ldmw177r _97oqou13 _97oqoud ldmw177i css-uwqhso e2upnqp0"
               >
-                카카오페이
+                {{ order.payMethod == "kakaopay" ? "카카오페이" : "토스페이" }}
               </p>
             </div>
           </div>
@@ -129,17 +129,17 @@
           <p
             class="_97oqoup _97oqouv _97oqou5 ldmw177c _97oqou19 _97oqouj ldmw177q _97oqou12 _97oqouc ldmw177j css-luewyl e1n2ou001"
           >
-            심키즈
+            {{ order.receiverName }}
           </p>
           <p
             class="_97oqoup _97oqouw _97oqou6 ldmw177b _97oqou1a _97oqouk ldmw177r _97oqou13 _97oqoud ldmw177i css-4qwok1 e1n2ou001"
           >
-            010-1234-****
+            {{ order.receiverPhoneNumber }}
           </p>
           <p
             class="_97oqoup _97oqouw _97oqou6 ldmw177b _97oqou1a _97oqouk ldmw177r _97oqou13 _97oqoud ldmw177i css-303o8l e1n2ou001"
           >
-            서울특별시 광진구 군자로0길 50-2
+            {{ order.address }}
           </p>
         </div>
       </div>
@@ -156,8 +156,9 @@
           불가능할 수 있습니다.
         </p>
         <button
-          disabled
+          :disabled="order.status !== '주문 완료'"
           class="tew5wjw tew5wj0 ldmw1780 tew5wjy tew5wj19 tew5wj1b tew5wj14 tew5wj3 ldmw1717i ldmw17183 ldmw1715v ldmw177b tew5wj17 tew5wj1c tew5wj5 ldmw177j tew5wj1l tew5wje ldmw17y6 ldmw17ok ldmw178w tew5wjp ldmw171du css-jz9jxv ecvmg6w2"
+          :class="{ 'able-cancel': order.status === '주문 완료' }"
         >
           <p
             class="_97oqoup _97oqouw _97oqou6 ldmw177b _97oqou1a _97oqouk ldmw177r _97oqou12 _97oqouc ldmw177j"
@@ -171,22 +172,39 @@
 </template>
 
 <script>
+import { mapStores } from "pinia";
+import { useOrderStore } from "@/stores/useOrderStore.js";
+
 export default {
+  created() {
+    this.setDetail();
+  },
   data() {
     return {
       isDetailsVisible: true,
       arrowRotated: false,
+      order: {},
     };
   },
   computed: {
-    arrowRotate() {
-      return this.arrowRotated ? "rotate(90deg)" : "rotate(0deg)";
-    },
+    ...mapStores(useOrderStore),
   },
   methods: {
-    toggleDetails() {
-      this.isDetailsVisible = !this.isDetailsVisible;
-      this.arrowRotated = !this.arrowRotated;
+    async setDetail() {
+      const response = await this.orderStore.getUserOrderDetail(
+        this.$route.params.orderId
+      );
+      this.order = response;
+    },
+    formattedDate(dateString) {
+      const date = new Date(dateString);
+      const year = date.getFullYear();
+      const month = ("0" + (date.getMonth() + 1)).slice(-2);
+      const day = ("0" + date.getDate()).slice(-2);
+      const hours = ("0" + date.getHours()).slice(-2);
+      const minutes = ("0" + date.getMinutes()).slice(-2);
+
+      return `${year}.${month}.${day} ${hours}:${minutes}`;
     },
   },
 };
@@ -1070,11 +1088,17 @@ input {
 .tew5wj1l:disabled {
   color: #222;
   background-color: #eceff3;
+  cursor: not-allowed;
 }
 
 button[disabled],
 input[disabled] {
   cursor: pointer;
+}
+
+.able-cancel {
+  color: rgb(255, 255, 255);
+  background-color: rgb(95, 0, 128);
 }
 
 .css-jz9jxv {

--- a/frontend/src/components/mypage/MypageOrderDetailComponent.vue
+++ b/frontend/src/components/mypage/MypageOrderDetailComponent.vue
@@ -177,6 +177,7 @@
           :disabled="order.status !== '주문 완료'"
           class="tew5wjw tew5wj0 ldmw1780 tew5wjy tew5wj19 tew5wj1b tew5wj14 tew5wj3 ldmw1717i ldmw17183 ldmw1715v ldmw177b tew5wj17 tew5wj1c tew5wj5 ldmw177j tew5wj1l tew5wje ldmw17y6 ldmw17ok ldmw178w tew5wjp ldmw171du css-jz9jxv ecvmg6w2"
           :class="{ 'able-cancel': order.status === '주문 완료' }"
+          @click="cancelOrder"
         >
           <p
             class="_97oqoup _97oqouw _97oqou6 ldmw177b _97oqou1a _97oqouk ldmw177r _97oqou12 _97oqouc ldmw177j"
@@ -223,6 +224,15 @@ export default {
       const minutes = ("0" + date.getMinutes()).slice(-2);
 
       return `${year}.${month}.${day} ${hours}:${minutes}`;
+    },
+    async cancelOrder() {
+      const confirmed = confirm("주문을 취소하시겠습니까?");
+      if (confirmed) {
+        await this.orderStore.cancelOrder(this.$route.params.orderId);
+
+        alert("주문이 성공적으로 취소되었습니다.");
+        this.$router.push("/mypage/order"); // 주문 목록 페이지로 이동 등
+      }
     },
   },
 };

--- a/frontend/src/components/mypage/MypageOrderDetailComponent.vue
+++ b/frontend/src/components/mypage/MypageOrderDetailComponent.vue
@@ -26,6 +26,20 @@
             <p
               class="_97oqoup _97oqouw _97oqou6 ldmw177b _97oqou1a _97oqouk ldmw177r _97oqou13 _97oqoud ldmw177i css-15bah7q e2upnqp0"
             >
+              주문 상태
+            </p>
+            <div class="css-8yre18 e2upnqp1">
+              <p
+                class="_97oqoup _97oqouw _97oqou6 ldmw177b _97oqou1a _97oqouk ldmw177r _97oqou13 _97oqoud ldmw177i css-uwqhso e2upnqp0"
+              >
+                {{ order.status }}
+              </p>
+            </div>
+          </div>
+          <div class="css-1aim50k e2upnqp1">
+            <p
+              class="_97oqoup _97oqouw _97oqou6 ldmw177b _97oqou1a _97oqouk ldmw177r _97oqou13 _97oqoud ldmw177i css-15bah7q e2upnqp0"
+            >
               결제 일시
             </p>
             <div class="css-8yre18 e2upnqp1">
@@ -56,7 +70,7 @@
             <p
               class="_97oqoup _97oqouw _97oqou6 ldmw177b _97oqou1a _97oqouk ldmw177r _97oqou12 _97oqouc ldmw177j"
             >
-              145,000원
+              {{ order.originalPaidAmount }}원
             </p>
           </div>
           <div class="css-1aim50k e2upnqp1">
@@ -69,7 +83,11 @@
               <p
                 class="_97oqoup _97oqouw _97oqou6 ldmw177b _97oqou1a _97oqouk ldmw177r _97oqou13 _97oqoud ldmw177i css-uwqhso e2upnqp0"
               >
-                -55,100원
+                -{{
+                  order.originalPaidAmount -
+                  order.usedPoint -
+                  order.totalPaidAmount
+                }}원
               </p>
             </div>
           </div>
@@ -111,7 +129,7 @@
               <p
                 class="_97oqoup _97oqouw _97oqou6 ldmw177b _97oqou1a _97oqouk ldmw177r _97oqou12 _97oqouc ldmw177j"
               >
-                90,900원
+                {{ order.totalPaidAmount }}원
               </p>
             </div>
           </div>

--- a/frontend/src/components/mypage/MypageOrderDetailComponent.vue
+++ b/frontend/src/components/mypage/MypageOrderDetailComponent.vue
@@ -228,10 +228,11 @@ export default {
     async cancelOrder() {
       const confirmed = confirm("주문을 취소하시겠습니까?");
       if (confirmed) {
-        await this.orderStore.cancelOrder(this.$route.params.orderId);
-
-        alert("주문이 성공적으로 취소되었습니다.");
-        this.$router.push("/mypage/order"); // 주문 목록 페이지로 이동 등
+        await this.orderStore.cancelOrder(
+          this.$route.params.orderId,
+          "/mypage/order",
+          "주문이 성공적으로 취소되었습니다."
+        );
       }
     },
   },

--- a/frontend/src/components/mypage/MypageOrderListComponent.vue
+++ b/frontend/src/components/mypage/MypageOrderListComponent.vue
@@ -1,12 +1,7 @@
 <template>
   <div class="css-heioij eug5r8l1">
-    <div
-      @click="goToOrderDetail(order.orderIdx)"
-      v-for="order in orderList"
-      :key="order.id"
-      class="order-item"
-    >
-      <MypageOrderComponent />
+    <div v-for="order in orderList" :key="order.id" class="order-item">
+      <MypageOrderComponent :order="order" />
     </div>
 
     <div class="css-rdz8z7 e82lnfz1">
@@ -128,10 +123,6 @@ export default {
     nextPageGroup() {
       const newPage = this.endPage + 1;
       this.goToPage(newPage);
-    },
-
-    goToOrderDetail(orderId) {
-      this.$router.push({ path: `/mypage/order/${orderId}` });
     },
   },
 };

--- a/frontend/src/components/mypage/MypageOrderListComponent.vue
+++ b/frontend/src/components/mypage/MypageOrderListComponent.vue
@@ -3,8 +3,11 @@
     <div v-for="order in orderList" :key="order.id" class="order-item">
       <MypageOrderComponent :order="order" />
     </div>
+    <div v-if="orderList.length === 0" class="empty-notice">
+      <p>주문 내역이 없습니다.</p>
+    </div>
 
-    <div class="css-rdz8z7 e82lnfz1">
+    <div class="css-rdz8z7 e82lnfz1" v-if="orderList.length !== 0">
       <a class="page-unselected e82lnfz0" @click="goToPage(1)"
         ><img
           src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAkAAAAHCAQAAABwkq/rAAAAHUlEQVR42mNgAIPi/8X/kWkwA8SE0UQIMJAsCKMBBzk27fqtkcYAAAAASUVORK5CYII="
@@ -99,7 +102,7 @@ export default {
       );
       this.orderList = response.content;
       this.totalPages = response.totalPages;
-      console.log(response);
+      console.log("요기!!!" + response + "  totalpage ==> " + this.totalPages);
     },
     goToPage(pageNumber) {
       if (pageNumber >= 1 && pageNumber <= this.totalPages) {
@@ -181,6 +184,23 @@ html {
   min-width: 1050px;
   background-color: rgb(242, 245, 248);
   padding: 20px 0;
+}
+
+.empty-notice {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  padding: 40px;
+  margin-top: 20px;
+  line-height: 20px;
+  letter-spacing: -0.2px;
+  background-color: rgb(255, 255, 255);
+  color: rgb(153, 153, 153);
+  border-radius: 16px;
+  font-size: 20px;
+  width: 100%;
+  height: 200px;
 }
 
 .css-72lz6z {

--- a/frontend/src/components/mypage/MypageOrderListComponent.vue
+++ b/frontend/src/components/mypage/MypageOrderListComponent.vue
@@ -88,9 +88,9 @@ export default {
     },
   },
   watch: {
-    "$route.query.page": "setBoards",
-    "$route.query.dateRange": "setBoards",
-    "$route.query.orderStatus": "setBoards",
+    "$route.query.page": "setOrderList",
+    "$route.query.dateRange": "setOrderList",
+    "$route.query.orderStatus": "setOrderList",
   },
   methods: {
     async setOrderList() {
@@ -106,8 +106,6 @@ export default {
         this.$router.push({
           query: {
             page: pageNumber,
-            dateRange: this.selectedDateRange,
-            orderStatus: this.selectedOrderStatus,
           },
         });
       } else if (pageNumber < 1) {

--- a/frontend/src/components/orders/OrdersMainComponent.vue
+++ b/frontend/src/components/orders/OrdersMainComponent.vue
@@ -138,8 +138,6 @@
                 </div>
               </div>
             </div>
-
-            <!--츄가아ㅏㅏㅏㅏ-->
             <div class="css-1gshg9u e150alo82">
               <span class="css-qq9ke6 e744wfw0">*</span>
               <span class="css-ln1csn e150alo81">전화번호</span>
@@ -525,6 +523,7 @@ export default {
           address: this.ordererInfo.defaultAddress, // 배송지 정보 가져오기
           usedPoint: this.usedPoint, // 사용한 포인트
           totalAmount: this.totalAmount, // 전체 결제금액에서 포인트 차감
+          originalPaidAmount: this.originalTotalAmount,
           receiverName: this.receiverName, // 사용자가 입력한 받는 사람 이름
           receiverPhoneNumber: this.receiverPhoneNumber, // 사용자가 입력한 전화번호
         };

--- a/frontend/src/components/orders/OrdersMainComponent.vue
+++ b/frontend/src/components/orders/OrdersMainComponent.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="css-1ykiyus">
+  <div class="css-1ykiyus" v-if="!isLoading">
     <div class="css-1uom1od">
       <h2 class="css-10owlr">주문서</h2>
       <div class="css-ixlb9s">
@@ -85,7 +85,7 @@
           <div class="css-yazyg9">
             <span class="css-ln1csn">휴대폰</span>
             <div class="css-82a6rk">
-              <div class="css-t6o2y8">{{ ordererInfo.phone }}</div>
+              <div class="css-t6o2y8">{{ ordererInfo.phoneNumber }}</div>
             </div>
           </div>
           <div class="css-yazyg9">
@@ -158,9 +158,13 @@
               <span class="css-qq9ke6 e744wfw0">*</span>
               <span class="css-ln1csn e150alo81">배송지</span>
               <div class="css-82a6rk e150alo80">
-                <span class="css-3uygi7 e17yjk9v3">기본배송지</span>
+                <span
+                  class="css-3uygi7 e17yjk9v3"
+                  :v-if="ordererInfo.selectedAddress.isDefault"
+                  >기본배송지</span
+                >
                 <p class="css-36j4vu e17yjk9v2">
-                  {{ ordererInfo.defaultAddress }}
+                  {{ ordererInfo.selectedAddress.address }}
                 </p>
                 <div class="css-iqoq9n e17yjk9v0">
                   <button
@@ -193,12 +197,11 @@
                   >
                     <span class="css-cp6cch e1gm2j0y4"
                       >최대 사용 가능 포인트 :
-                      {{ maximumAvailablePoint.toLocaleString() }}
+                      {{ maximumAvailablePoint }}
                       <span class="css-o5boot e1gm2j0y5">p</span></span
                     >
                     <span class="css-o5boot e1gm2j0y5"
-                      >보유 포인트 :
-                      {{ ordererInfo.point.toLocaleString() }} p</span
+                      >보유 포인트 : {{ ordererInfo.point }} p</span
                     >
                   </div>
                 </div>
@@ -391,6 +394,7 @@ export default {
   name: "OrdersPage",
   data() {
     return {
+      isLoading: true, // 로딩 상태
       isIconRotated: false,
       isToggleContentVisible: false,
       isDeliveryNotiVisible: false,
@@ -427,42 +431,57 @@ export default {
     },
   },
   created() {
-    if (
-      this.orderStore.boardInfo == null ||
-      /*this.orderStore.orderedProducts == null*/
-      this.orderStore.orderInfo.orderedProducts == null
-    ) {
-      return this.$router.push("/");
-    }
-
-    this.boardInfo = this.orderStore.boardInfo;
-    this.orderedProducts = this.orderStore.orderInfo.orderedProducts; //this.orderStore.orderedProducts;
-
-    this.ordererInfo = {
-      // this.ordererInfo = this.userStore.
-      name: "유송연",
-      phone: "010-1111-1111",
-      email: "simkids@gmail.com",
-      point: 24890,
-      defaultAddress:
-        " 서울 동작구 상도로 지하 76 (7호선 신대방삼거리역) Beyond SW 캠프",
-    };
-
-    let tenPercentOfPrice = Math.round(this.totalAmount * (10 / 100));
-
-    this.maximumAvailablePoint =
-      this.ordererInfo.point < tenPercentOfPrice
-        ? this.ordererInfo.point
-        : tenPercentOfPrice;
-
-    history.pushState(null, null, location.href);
-    window.addEventListener("popstate", this.handlePopState);
+    this.init();
   },
   beforeUnmount() {
     window.removeEventListener("popstate", this.handlePopState);
   },
 
   methods: {
+    async init() {
+      if (
+        this.orderStore.boardInfo == null ||
+        this.orderStore.orderInfo.orderedProducts == null
+      ) {
+        return this.$router.push("/");
+      }
+
+      this.boardInfo = this.orderStore.boardInfo;
+      this.orderedProducts = this.orderStore.orderInfo.orderedProducts;
+
+      const result = await this.userStore.getDetail();
+
+      if (result == true) {
+        const defaultDelivery = this.userStore.userDetail.deliveries.find(
+          (delivery) => delivery.isDefault
+        );
+
+        this.ordererInfo = {
+          ...this.userStore.userDetail,
+          point: 0,
+          selectedAddress: defaultDelivery,
+        };
+
+        console.log(
+          "===============>" + this.ordererInfo.selectedAddress.isDefault
+        );
+
+        let tenPercentOfPrice = Math.round(this.totalAmount * (10 / 100));
+
+        this.maximumAvailablePoint =
+          this.ordererInfo.point < tenPercentOfPrice
+            ? this.ordererInfo.point
+            : tenPercentOfPrice;
+
+        history.pushState(null, null, location.href);
+        window.addEventListener("popstate", this.handlePopState);
+
+        this.isLoading = false; // 데이터 로딩 완료 후 로딩 상태 해제
+      } else {
+        alert("로그인 후 이용해주세요.");
+        return this.$router.push("/");
+      }
+    },
     async handlePopState() {
       this.orderStore.cancelOrder(
         this.orderStore.orderInfo.orderIdx,
@@ -520,7 +539,7 @@ export default {
       if (this.validateAll()) {
         const paymentData = {
           paymentMethod: this.selectedPaymentMethod,
-          address: this.ordererInfo.defaultAddress, // 배송지 정보 가져오기
+          deliveryIdx: this.ordererInfo.selectedAddress.idx, // 배송지 정보 가져오기
           usedPoint: this.usedPoint, // 사용한 포인트
           totalAmount: this.totalAmount, // 전체 결제금액에서 포인트 차감
           originalPaidAmount: this.originalTotalAmount,

--- a/frontend/src/pages/user/MyPage.vue
+++ b/frontend/src/pages/user/MyPage.vue
@@ -20,8 +20,8 @@ import HeaderComponent from "@/components/common/HeaderComponent.vue";
 import MypageAsideComponent from "@/components/mypage/MypageAsideComponent.vue";
 import FooterComponent from "@/components/common/FooterComponent.vue";
 import TitleComponent from "@/components/mypage/TitleComponent.vue";
-import { useUserStore } from '@/stores/useUserStore';
-import { mapStores } from 'pinia';
+import { useUserStore } from "@/stores/useUserStore";
+import { mapStores } from "pinia";
 
 export default {
   name: "MyPage",
@@ -51,26 +51,27 @@ export default {
         this.currentTitle = "배송지 관리";
         await this.getDeliveryList();
         this.$router.push("/mypage/address");
-      }else if (menu === "info"){
+      } else if (menu === "info") {
         await this.getUserInfo();
       }
-      
     },
-    async getUserInfo(){
-      if(await this.userStore.getDetail()){
+    async getUserInfo() {
+      if (await this.userStore.getDetail()) {
         alert("성공");
-      }else{
+      } else {
         alert("회원정보를 가져오는데 실패했습니다.");
       }
     },
-    async getDeliveryList(){
-      if(!await this.userStore.getDeliveryList()){
+    async getDeliveryList() {
+      if (!(await this.userStore.getDeliveryList())) {
         alert("회원정보를 가져오는데 실패했습니다.");
       }
     },
     updateTitleBasedOnRoute() {
       const currentRoute = this.$route.path;
-      if (currentRoute.includes("order")) {
+      if (currentRoute.includes("order/")) {
+        this.currentTitle = "주문 상세";
+      } else if (currentRoute.includes("order")) {
         this.currentTitle = "주문 내역";
       } else if (currentRoute.includes("qna")) {
         this.currentTitle = "My 문의";
@@ -83,7 +84,7 @@ export default {
     },
   },
   computed: {
-    ...mapStores(useUserStore)
+    ...mapStores(useUserStore),
   },
   mounted() {
     this.updateTitleBasedOnRoute(); // 페이지 로드 시 현재 경로에 따라 타이틀 설정

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -25,6 +25,7 @@ import MyPageAddressComponent from "@/components/mypage/MypageAddressComponent.v
 import CompanyQnAListPage from "@/pages/company/qna/CompanyQnAListPage.vue";
 import LoginRedirectPage from "@/pages/common/LoginRedirectPage.vue";
 import SocialSignupComponent from "@/components/user/SocialSignupComponent.vue";
+import MypageOrderDetail from "@/components/mypage/MypageOrderDetailComponent.vue"
 
 const router = createRouter({
   history: createWebHistory(),
@@ -83,14 +84,15 @@ const router = createRouter({
           component: FindIdComponent,
           meta: { requiresAuth: false },
         },
-        { path: "social/signup",
+        {
+          path: "social/signup",
           component: SocialSignupComponent,
-          meta: {requiresAuth: false}
+          meta: { requiresAuth: false }
         },
         { path: "", redirect: "/auth/login", meta: { requiresAuth: false } },
       ],
     },
-    { path: "/login/redirect", component: LoginRedirectPage},
+    { path: "/login/redirect", component: LoginRedirectPage },
     {
       path: "/board",
       component: BoardListPage,
@@ -134,6 +136,7 @@ const router = createRouter({
       redirect: "/mypage/order",
       children: [
         { path: "order", component: MypageOrderListComponent },
+        { path: 'order/:orderId', component: MypageOrderDetail },
         { path: "qna", component: MypageQnAComponent },
         { path: "likes", component: MypageLikesEventComponent },
         { path: "address", component: MyPageAddressComponent },

--- a/frontend/src/stores/useOrderStore.js
+++ b/frontend/src/stores/useOrderStore.js
@@ -89,6 +89,8 @@ export const useOrderStore = defineStore('order', {
                 adderessDetail: "4층 강의실",
                 postNumber: "01677",
                 paymentId: this.paymentInfo.impUid,
+                originalPaidAmount: this.paymentInfo.originalPaidAmount,
+                totalPaidAmount: this.paymentInfo.totalAmount,
                 payMethod: this.paymentInfo.paymentMethod,
                 usedPoint: this.paymentInfo.usedPoint,
                 receiverName: this.paymentInfo.receiverName,
@@ -125,13 +127,14 @@ export const useOrderStore = defineStore('order', {
                 params: {
                     page: page
                 },
-            });
+
+            }, { withCredentials: true });
             return response.data.result;
         },
 
         async getUserOrderDetail(orderIdx) {
 
-            const response = await axios.get(`/api/orders/user/${orderIdx}/detail`);
+            const response = await axios.get(`/api/orders/user/${orderIdx}/detail`, { withCredentials: true });
             return response.data.result;
         },
 

--- a/frontend/src/stores/useOrderStore.js
+++ b/frontend/src/stores/useOrderStore.js
@@ -14,6 +14,12 @@ export const useOrderStore = defineStore('order', {
         customData: { products: [], discountRate: null, usedPoint: null }
     }),
     actions: {
+        initData() {
+            this.boardInfo = null;
+            this.orderInfo = { orderIdx: null, orderedProducts: [] }
+            this.paymentInfo = { impUid: null, paymentMethod: null, addredss: null, usedPoint: null, totalAmount: null, receiverName: null, receiverPhoneNumber: null }
+            this.customData = { products: [], discountRate: null, usedPoint: null }
+        },
         async submitOrder(orderRequest) {
             this.boardInfo = orderRequest.boardInfo;
             this.orderInfo.orderedProducts = orderRequest.cartItems;
@@ -33,6 +39,7 @@ export const useOrderStore = defineStore('order', {
 
                 if (response.data.code !== 1000) {
                     alert(`${response.data.message}`);
+                    this.initData();
                     return false;
                 }
 
@@ -44,6 +51,7 @@ export const useOrderStore = defineStore('order', {
 
             } catch (error) {
                 alert("주문에 실패했습니다\n\n반복적인 문제 발생시 고객센터로 문의바랍니다.");
+                this.initData();
                 return false;
             }
         },
@@ -66,11 +74,12 @@ export const useOrderStore = defineStore('order', {
 
                 if (paymentRequest.paymentMethod === 'kakaopay' && !rsp.success) {
                     this.cancelOrder(this.orderInfo.orderIdx, '/', '결제가 취소되었습니다. 주문이 취소됩니다.')
-
+                    this.initData()
                 }
 
                 else if (paymentRequest.paymentMethod === 'tosspay' && rsp.error_msg != null) {
                     this.cancelOrder(this.orderInfo.orderIdx, '/', '결제가 취소되었습니다. 주문이 취소됩니다.')
+                    this.initData()
                 }
 
                 else {
@@ -103,14 +112,17 @@ export const useOrderStore = defineStore('order', {
 
                 if (response.data.code !== 1000) {
                     alert(`결제에 실패했습니다\n\n반복적인 문제 발생시 고객센터로 문의바랍니다.\n\n${response.data.message}`);
+                    this.initData()
                     return router.push('/');
                 }
 
                 alert("결제가 성공적으로 완료되었습니다.");
+                this.initData()
                 router.push('/');
 
             } catch (error) {
                 alert("결제에 실패했습니다\n\n반복적인 문제 발생시 고객센터로 문의바랍니다.");
+                this.initData()
                 router.push('/');
             }
         },

--- a/frontend/src/stores/useOrderStore.js
+++ b/frontend/src/stores/useOrderStore.js
@@ -118,6 +118,22 @@ export const useOrderStore = defineStore('order', {
 
             alert(errMsg);
             router.push(root);
-        }
+        },
+
+        async getUserOrderListWithOption(page) {
+            const response = await axios.get("/api/orders/user/history", {
+                params: {
+                    page: page
+                },
+            });
+            return response.data.result;
+        },
+
+        async getUserOrderDetail(orderIdx) {
+
+            const response = await axios.get(`/api/orders/company/${orderIdx}/detail`);
+            return response.data.result;
+        },
+
     }
 });

--- a/frontend/src/stores/useOrderStore.js
+++ b/frontend/src/stores/useOrderStore.js
@@ -127,10 +127,10 @@ export const useOrderStore = defineStore('order', {
             }
         },
 
-        async cancelOrder(orderIdx, root, errMsg) {
+        async cancelOrder(orderIdx, root, msg) {
             await axios.patch(backend + `/${orderIdx}/cancel`, { withCredentials: true });
 
-            alert(errMsg);
+            alert(msg);
             router.push(root);
         },
 

--- a/frontend/src/stores/useOrderStore.js
+++ b/frontend/src/stores/useOrderStore.js
@@ -131,7 +131,7 @@ export const useOrderStore = defineStore('order', {
 
         async getUserOrderDetail(orderIdx) {
 
-            const response = await axios.get(`/api/orders/company/${orderIdx}/detail`);
+            const response = await axios.get(`/api/orders/user/${orderIdx}/detail`);
             return response.data.result;
         },
 

--- a/frontend/src/stores/useOrderStore.js
+++ b/frontend/src/stores/useOrderStore.js
@@ -94,9 +94,7 @@ export const useOrderStore = defineStore('order', {
 
             let request = {
                 orderIdx: this.orderInfo.orderIdx,
-                address: this.paymentInfo.address,
-                adderessDetail: "4층 강의실",
-                postNumber: "01677",
+                deliveryIdx: this.paymentInfo.deliveryIdx,
                 paymentId: this.paymentInfo.impUid,
                 originalPaidAmount: this.paymentInfo.originalPaidAmount,
                 totalPaidAmount: this.paymentInfo.totalAmount,


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #87 , #89 

<br>
 

## 📝 작업 내용

마이페이지 주문내역에서 회원의 주문 내역 과 주문 상세 정보를 조회할 수 있는 기능을 구현하였습니다.
- useOrderStore 수정(백엔드 api 연결)
- mypage order list, order detail 컴포넌트화
- 주문 취소 api 연결

<br>

## **💬 리뷰 요구사항(선택)**

> `backend/feature/mypage-orders` 브랜치와 함께 진행해주세요! (일반사용자 로그인 필수)
- [x] **일반 사용자 로그인 후**, `/board/detail/1` 에서 주문 진행
  - [x] 주문자 정보가 제대로 되어있는지 확인(이메일, 휴대폰 번호, 이름)
  - [x] 배송지 정보가 기본 배송지로 세팅되었는지 확인

<br>

- [x] **결제 완료후**, `/mypage/order` 에서 주문 내역에 데이터 생성되었는지 확인
  - [x] '>' 눌렀을 때, 주문 상세 정보 페이지로 라우팅 되는지 확인
  - [x] 주문 완료된 주문일 경우, 주문 취소 버튼 활성화 확인
  - [x] 주문 취소 눌렀을 때, `/mypage/order`로 라우팅되고, 주문 상태가 '주문취소'로 변했는지 확인
  - [x] 다시 상세보기 눌렀을 때, 주문 취소버튼 비활성화 확인
