### PR TITLE
[#45, #47] 답변 등록 (업체회원) 기능 구현, 답변 삭제 (업체회원) 기능 구현

### DIFF
--- a/backend/src/main/java/org/example/backend/domain/board/repository/ProductBoardRepository.java
+++ b/backend/src/main/java/org/example/backend/domain/board/repository/ProductBoardRepository.java
@@ -1,5 +1,6 @@
 package org.example.backend.domain.board.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.example.backend.domain.board.model.entity.ProductBoard;
@@ -10,4 +11,6 @@ import org.springframework.data.jpa.repository.Query;
 public interface ProductBoardRepository extends JpaRepository<ProductBoard, Long>, ProductBoardRepositoryCustom {
 	@Query("SELECT pb FROM ProductBoard pb JOIN fetch pb.category WHERE pb.idx = :idx")
 	Optional<ProductBoard> findByIdx(Long idx);
+
+	List<ProductBoard> findByCompanyEmail(String companyEmail);
 }

--- a/backend/src/main/java/org/example/backend/domain/qna/controller/AnswerController.java
+++ b/backend/src/main/java/org/example/backend/domain/qna/controller/AnswerController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/qnawer")
+@RequestMapping("/qna/answer")
 @RequiredArgsConstructor
 public class AnswerController {
 

--- a/backend/src/main/java/org/example/backend/domain/qna/controller/AnswerController.java
+++ b/backend/src/main/java/org/example/backend/domain/qna/controller/AnswerController.java
@@ -1,4 +1,39 @@
 package org.example.backend.domain.qna.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.example.backend.domain.qna.model.dto.AnswerDto;
+import org.example.backend.domain.qna.service.AnswerService;
+import org.example.backend.global.common.constants.BaseResponse;
+import org.example.backend.global.common.constants.BaseResponseStatus;
+import org.example.backend.global.exception.InvalidCustomException;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/qnawer")
+@RequiredArgsConstructor
 public class AnswerController {
+
+    private final AnswerService answerService;
+
+    @Operation(summary = "답변 등록 API", description = "기업회원이 문의에 대한 답변을 등록합니다.")
+    @PostMapping("/create")
+    public BaseResponse createAnswer(@RequestBody AnswerDto.AnswerCreateRequest request, @AuthenticationPrincipal UserDetails userDetails) {
+        try {
+            String email = userDetails.getUsername(); // 인증된 기업회원 이메일
+
+            // 답변 등록 서비스 호출
+            answerService.createAnswer(request, email);
+            return new BaseResponse<>(BaseResponseStatus.SUCCESS);
+        } catch (InvalidCustomException e) {
+            return new BaseResponse<>(e.getStatus());
+        } catch (Exception e) {
+            return new BaseResponse<>(BaseResponseStatus.FAIL);
+        }
+    }
 }

--- a/backend/src/main/java/org/example/backend/domain/qna/controller/AnswerController.java
+++ b/backend/src/main/java/org/example/backend/domain/qna/controller/AnswerController.java
@@ -9,10 +9,7 @@ import org.example.backend.global.common.constants.BaseResponseStatus;
 import org.example.backend.global.exception.InvalidCustomException;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/qna/answer")
@@ -29,6 +26,20 @@ public class AnswerController {
 
             // 답변 등록 서비스 호출
             answerService.createAnswer(request, email);
+            return new BaseResponse<>(BaseResponseStatus.SUCCESS);
+        } catch (InvalidCustomException e) {
+            return new BaseResponse<>(e.getStatus());
+        } catch (Exception e) {
+            return new BaseResponse<>(BaseResponseStatus.FAIL);
+        }
+    }
+
+    @Operation(summary = "답변 삭제 API", description = "답변을 삭제합니다.")
+    @DeleteMapping("/delete/{id}")
+    public BaseResponse deleteAnswer(@PathVariable Long id, @AuthenticationPrincipal UserDetails userDetails) {
+        try {
+            String email = userDetails.getUsername(); // 인증된 기업회원 이메일
+            answerService.deleteAnswer(id, email);
             return new BaseResponse<>(BaseResponseStatus.SUCCESS);
         } catch (InvalidCustomException e) {
             return new BaseResponse<>(e.getStatus());

--- a/backend/src/main/java/org/example/backend/domain/qna/controller/QuestionController.java
+++ b/backend/src/main/java/org/example/backend/domain/qna/controller/QuestionController.java
@@ -66,4 +66,17 @@ public class QuestionController {
         List<QuestionDto.QuestionListResponse> questionList = questionService.getQuestions();
         return new BaseResponse<>(questionList);
     }
+
+    @DeleteMapping("/delete/{id}")
+    public BaseResponse deleteQuestion(@PathVariable Long id, @AuthenticationPrincipal UserDetails userDetails){
+        try{
+            String email = userDetails.getUsername();
+            questionService.deleteQuestion(id, email);
+            return new BaseResponse<>(BaseResponseStatus.SUCCESS);
+        } catch (InvalidCustomException e) {
+            return new BaseResponse<>(e.getStatus());
+        } catch (Exception e) {
+            return new BaseResponse<>(BaseResponseStatus.QNA_QUESTION_DELETE_FAIL);
+        }
+    }
 }

--- a/backend/src/main/java/org/example/backend/domain/qna/controller/QuestionController.java
+++ b/backend/src/main/java/org/example/backend/domain/qna/controller/QuestionController.java
@@ -79,4 +79,21 @@ public class QuestionController {
             return new BaseResponse<>(BaseResponseStatus.QNA_QUESTION_DELETE_FAIL);
         }
     }
+
+    @Operation(summary = "문의 목록 조회 API", description = "로그인된 기업 회원이 자신의 게시글에 달린 문의만 조회합니다.")
+    @GetMapping("/list/company")
+    public BaseResponse<List<QuestionDto.QuestionListResponse>> getCompanyQuestions(
+            @AuthenticationPrincipal UserDetails userDetails) {
+        try {
+            String companyEmail = userDetails.getUsername();  // 인증된 기업 회원의 이메일 가져오기
+
+            // 기업 회원의 이메일을 기반으로 게시글에 달린 문의 조회
+            List<QuestionDto.QuestionListResponse> questionList = questionService.getQuestionsByCompanyEmail(companyEmail);
+            return new BaseResponse<>(questionList);
+        } catch (InvalidCustomException e) {
+            return new BaseResponse<>(e.getStatus());
+        } catch (Exception e) {
+            return new BaseResponse<>(BaseResponseStatus.FAIL);
+        }
+    }
 }

--- a/backend/src/main/java/org/example/backend/domain/qna/controller/QuestionController.java
+++ b/backend/src/main/java/org/example/backend/domain/qna/controller/QuestionController.java
@@ -36,28 +36,12 @@ public class QuestionController {
             ))
 
     @PostMapping("/create")
-    public BaseResponse create(@RequestBody QuestionDto.QuestionCreateRequest request, @AuthenticationPrincipal UserDetails userDetails){
-        try{
-            String email = userDetails.getUsername(); // 인증된 사용자의 이메일 가져오기
+    public BaseResponse create(@RequestBody QuestionDto.QuestionCreateRequest request, @AuthenticationPrincipal UserDetails userDetails) {
+        String email = userDetails.getUsername(); // 인증된 사용자의 이메일 가져오기
+        Long productBoardIdx = request.getProductBoardIdx();  // Request Body로 전달받은 productBoardIdx 사용
 
-            if (request.getTitle() == null || request.getTitle().trim().isEmpty()) {
-                throw new InvalidCustomException(BaseResponseStatus.QNA_QUESTION_FAIL_EMPTY_TITLE);
-            }
-            if (request.getContent() == null || request.getContent().trim().isEmpty()) {
-                throw new InvalidCustomException(BaseResponseStatus.QNA_QUESTION_FAIL_EMPTY_CONTENT);
-            }
-
-            Long productBoardIdx = request.getProductBoardIdx();  // Request Body로 전달받은 productBoardIdx 사용
-
-            // 문의 등록 후 사용자 이름, 날짜, 답변 상태를 함께 응답
-            QuestionDto.QuestionCreateResponse response = questionService.createQuestion(request, email, productBoardIdx);
-            return new BaseResponse<>(response);
-
-        } catch (InvalidCustomException e){
-            return new  BaseResponse<>(e.getStatus());
-        } catch (Exception e){
-            return new BaseResponse<>(BaseResponseStatus.FAIL);
-        }
+        QuestionDto.QuestionCreateResponse response = questionService.createQuestion(request, email, productBoardIdx);
+        return new BaseResponse<>(response);
     }
 
     @Operation(summary = "문의 목록 조회 API", description = "DB에 저장된 문의 목록을 반환합니다.")
@@ -68,32 +52,17 @@ public class QuestionController {
     }
 
     @DeleteMapping("/delete/{id}")
-    public BaseResponse deleteQuestion(@PathVariable Long id, @AuthenticationPrincipal UserDetails userDetails){
-        try{
-            String email = userDetails.getUsername();
-            questionService.deleteQuestion(id, email);
-            return new BaseResponse<>(BaseResponseStatus.SUCCESS);
-        } catch (InvalidCustomException e) {
-            return new BaseResponse<>(e.getStatus());
-        } catch (Exception e) {
-            return new BaseResponse<>(BaseResponseStatus.QNA_QUESTION_DELETE_FAIL);
-        }
+    public BaseResponse deleteQuestion(@PathVariable Long id, @AuthenticationPrincipal UserDetails userDetails) {
+        String email = userDetails.getUsername();
+        questionService.deleteQuestion(id, email);
+        return new BaseResponse<>(BaseResponseStatus.SUCCESS);
     }
 
     @Operation(summary = "문의 목록 조회 API", description = "로그인된 기업 회원이 자신의 게시글에 달린 문의만 조회합니다.")
     @GetMapping("/list/company")
-    public BaseResponse<List<QuestionDto.QuestionListResponse>> getCompanyQuestions(
-            @AuthenticationPrincipal UserDetails userDetails) {
-        try {
-            String companyEmail = userDetails.getUsername();  // 인증된 기업 회원의 이메일 가져오기
-
-            // 기업 회원의 이메일을 기반으로 게시글에 달린 문의 조회
-            List<QuestionDto.QuestionListResponse> questionList = questionService.getQuestionsByCompanyEmail(companyEmail);
-            return new BaseResponse<>(questionList);
-        } catch (InvalidCustomException e) {
-            return new BaseResponse<>(e.getStatus());
-        } catch (Exception e) {
-            return new BaseResponse<>(BaseResponseStatus.FAIL);
-        }
+    public BaseResponse<List<QuestionDto.QuestionListResponse>> getCompanyQuestions(@AuthenticationPrincipal UserDetails userDetails) {
+        String companyEmail = userDetails.getUsername();  // 인증된 기업 회원의 이메일 가져오기
+        List<QuestionDto.QuestionListResponse> questionList = questionService.getQuestionsByCompanyEmail(companyEmail);
+        return new BaseResponse<>(questionList);
     }
 }

--- a/backend/src/main/java/org/example/backend/domain/qna/model/dto/AnswerDto.java
+++ b/backend/src/main/java/org/example/backend/domain/qna/model/dto/AnswerDto.java
@@ -1,4 +1,42 @@
 package org.example.backend.domain.qna.model.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.backend.domain.company.model.entity.Company;
+import org.example.backend.domain.qna.model.entity.Answer;
+import org.example.backend.domain.qna.model.entity.Question;
+
+import java.time.LocalDateTime;
+
 public class AnswerDto {
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class AnswerCreateRequest {
+        private Long questionIdx;
+        private String content;
+
+        public Answer toEntity(Company company, Question question) {
+            return Answer.builder()
+                    .content(this.content)
+                    .company(company)
+                    .question(question)
+                    .createdAt(LocalDateTime.now())
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class AnswerResponse {
+        private Long idx;
+        private String content;
+        private String companyName;
+        private LocalDateTime createdAt;
+    }
 }

--- a/backend/src/main/java/org/example/backend/domain/qna/model/dto/QuestionDto.java
+++ b/backend/src/main/java/org/example/backend/domain/qna/model/dto/QuestionDto.java
@@ -44,6 +44,7 @@ public class QuestionDto {
     @AllArgsConstructor
     @NoArgsConstructor
     public static class QuestionCreateResponse{
+        private Long idx;
         private String title;
         private String content;
         private String userName;
@@ -56,10 +57,12 @@ public class QuestionDto {
     @AllArgsConstructor
     @NoArgsConstructor
     public static class QuestionListResponse {
+        private Long idx;
         private String title;
         private String content;
         private String userName;
         private String answerStatus;
         private LocalDateTime createdAt;
+        private String email;
     }
 }

--- a/backend/src/main/java/org/example/backend/domain/qna/model/dto/QuestionDto.java
+++ b/backend/src/main/java/org/example/backend/domain/qna/model/dto/QuestionDto.java
@@ -12,6 +12,7 @@ import org.example.backend.domain.user.model.entity.User;
 import org.example.backend.global.common.constants.AnswerStatus;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class QuestionDto {
 
@@ -50,6 +51,9 @@ public class QuestionDto {
         private String userName;
         private String answerStatus;
         private LocalDateTime createdAt;
+
+        private String answerContent;
+        private LocalDateTime answerCreatedAt;
     }
 
     @Getter
@@ -64,5 +68,7 @@ public class QuestionDto {
         private String answerStatus;
         private LocalDateTime createdAt;
         private String email;
+
+        private List<AnswerDto.AnswerResponse> answers;
     }
 }

--- a/backend/src/main/java/org/example/backend/domain/qna/model/dto/QuestionDto.java
+++ b/backend/src/main/java/org/example/backend/domain/qna/model/dto/QuestionDto.java
@@ -68,6 +68,7 @@ public class QuestionDto {
         private String answerStatus;
         private LocalDateTime createdAt;
         private String email;
+        private Long productBoardIdx;
 
         private List<AnswerDto.AnswerResponse> answers;
     }

--- a/backend/src/main/java/org/example/backend/domain/qna/model/entity/Answer.java
+++ b/backend/src/main/java/org/example/backend/domain/qna/model/entity/Answer.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.example.backend.domain.company.model.entity.Company;
+import org.example.backend.domain.qna.model.dto.AnswerDto;
 
 import java.time.LocalDateTime;
 
@@ -31,4 +32,14 @@ public class Answer {
     private Question question;
 
     private LocalDateTime createdAt;
+
+    // DTO 변환 메서드: 답변 조회 응답
+    public AnswerDto.AnswerResponse toResponse() {
+        return AnswerDto.AnswerResponse.builder()
+                .idx(this.idx)
+                .content(this.content)
+                .companyName(this.company.getName())
+                .createdAt(this.createdAt)
+                .build();
+    }
 }

--- a/backend/src/main/java/org/example/backend/domain/qna/model/entity/Answer.java
+++ b/backend/src/main/java/org/example/backend/domain/qna/model/entity/Answer.java
@@ -1,4 +1,34 @@
 package org.example.backend.domain.qna.model.entity;
 
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.backend.domain.company.model.entity.Company;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class Answer {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long idx;
+
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "company_idx")
+    private Company company;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "question_idx")
+    private Question question;
+
+    private LocalDateTime createdAt;
 }

--- a/backend/src/main/java/org/example/backend/domain/qna/model/entity/Question.java
+++ b/backend/src/main/java/org/example/backend/domain/qna/model/entity/Question.java
@@ -3,6 +3,8 @@ package org.example.backend.domain.qna.model.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.example.backend.domain.board.model.entity.ProductBoard;
+import org.example.backend.domain.qna.model.dto.AnswerDto;
+import org.example.backend.domain.qna.model.dto.QuestionDto;
 import org.example.backend.domain.user.model.entity.User;
 import org.example.backend.global.common.constants.AnswerStatus;
 import org.springframework.data.annotation.CreatedDate;
@@ -11,6 +13,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Entity
 @Getter
@@ -47,6 +50,37 @@ public class Question {
 
     @Column(name = "answer_status")
     private String answerStatus = AnswerStatus.ANSWER_WAITING.getStatus();
+
+    // DTO 변환 메서드: 문의 생성 후 응답
+    public QuestionDto.QuestionCreateResponse toCreateResponse() {
+        return QuestionDto.QuestionCreateResponse.builder()
+                .idx(this.idx)
+                .title(this.title)
+                .content(this.content)
+                .userName(this.user.getName())
+                .answerStatus(this.answerStatus)
+                .createdAt(this.createdAt)
+                .build();
+    }
+
+    // DTO 변환 메서드: 문의 목록 조회
+    public QuestionDto.QuestionListResponse toListResponse() {
+        List<AnswerDto.AnswerResponse> answerResponses = this.answers.stream()
+                .map(answer -> answer.toResponse())
+                .collect(Collectors.toList());
+
+        return QuestionDto.QuestionListResponse.builder()
+                .idx(this.idx)
+                .title(this.title)
+                .content(this.content)
+                .userName(this.user.getName())
+                .answerStatus(this.answerStatus)
+                .createdAt(this.createdAt)
+                .email(this.user.getEmail())
+                .answers(answerResponses)  // 답변 리스트 포함
+                .productBoardIdx(getProductBoard().getIdx())
+                .build();
+    }
 
     // 답변이 등록 되면 문의 상태를 "답변완료"로 변경하는 메서드
     public void markAsAnswered(){

--- a/backend/src/main/java/org/example/backend/domain/qna/model/entity/Question.java
+++ b/backend/src/main/java/org/example/backend/domain/qna/model/entity/Question.java
@@ -1,18 +1,16 @@
 package org.example.backend.domain.qna.model.entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.example.backend.domain.board.model.entity.ProductBoard;
 import org.example.backend.domain.user.model.entity.User;
 import org.example.backend.global.common.constants.AnswerStatus;
 import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -37,11 +35,13 @@ public class Question {
     @JoinColumn(name = "product_board_idx")
     private ProductBoard productBoard;
 
+    @OneToMany(mappedBy = "question", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Answer> answers = new ArrayList<>();
+
     @CreatedDate
     @Column(updatable = false)
     private LocalDateTime createdAt;
 
-    @LastModifiedDate
     @Column(insertable = false)
     private LocalDateTime modifiedAt;
 
@@ -49,7 +49,18 @@ public class Question {
     private String answerStatus = AnswerStatus.ANSWER_WAITING.getStatus();
 
     // 답변이 등록 되면 문의 상태를 "답변완료"로 변경하는 메서드
-//    public void markAsAnswered(){
-//        this.answerStatus = AnswerStatus.ANSWER_COMPLETED.getStatus();
-//    }
+    public void markAsAnswered(){
+        this.answerStatus = AnswerStatus.ANSWER_COMPLETED.getStatus();
+    }
+
+    // 답변 상태를 "답변 대기"로 변경하는 메서드
+    public void markAsWaiting() {
+        this.answerStatus = AnswerStatus.ANSWER_WAITING.getStatus();
+    }
+
+    // 문의 수정 시에만 수정 시간(modifiedAt) 갱신
+    public void updateContent(String newContent) {
+        this.content = newContent;
+        this.modifiedAt = LocalDateTime.now();  // 문의가 수정될 때만 modifiedAt 갱신
+    }
 }

--- a/backend/src/main/java/org/example/backend/domain/qna/repository/AnswerRepository.java
+++ b/backend/src/main/java/org/example/backend/domain/qna/repository/AnswerRepository.java
@@ -1,4 +1,11 @@
 package org.example.backend.domain.qna.repository;
 
-public interface AnswerRepository {
+import org.example.backend.domain.qna.model.entity.Answer;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface AnswerRepository extends JpaRepository<Answer, Long> {
+    // 특정 문의에 달린 모든 답변을 리스트로 반환
+    List<Answer> findAllByQuestionIdx(Long questionIdx);
 }

--- a/backend/src/main/java/org/example/backend/domain/qna/repository/QuestionRepository.java
+++ b/backend/src/main/java/org/example/backend/domain/qna/repository/QuestionRepository.java
@@ -1,9 +1,11 @@
 package org.example.backend.domain.qna.repository;
 
+import org.example.backend.domain.board.model.entity.ProductBoard;
 import org.example.backend.domain.qna.model.entity.Question;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface QuestionRepository extends JpaRepository<Question, Long> {
+    List<Question> findByProductBoardIn(List<ProductBoard> productBoards);
 }

--- a/backend/src/main/java/org/example/backend/domain/qna/service/AnswerService.java
+++ b/backend/src/main/java/org/example/backend/domain/qna/service/AnswerService.java
@@ -1,4 +1,50 @@
 package org.example.backend.domain.qna.service;
 
+import lombok.RequiredArgsConstructor;
+import org.example.backend.domain.board.model.entity.ProductBoard;
+import org.example.backend.domain.qna.model.dto.AnswerDto;
+import org.example.backend.domain.qna.model.entity.Answer;
+import org.example.backend.domain.qna.model.entity.Question;
+import org.example.backend.domain.qna.repository.AnswerRepository;
+import org.example.backend.domain.qna.repository.QuestionRepository;
+import org.example.backend.domain.company.model.entity.Company;
+import org.example.backend.domain.company.repository.CompanyRepository;
+import org.example.backend.global.common.constants.AnswerStatus;
+import org.example.backend.global.common.constants.BaseResponseStatus;
+import org.example.backend.global.exception.InvalidCustomException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
 public class AnswerService {
+
+    private final AnswerRepository answerRepository;
+    private final QuestionRepository questionRepository;
+    private final CompanyRepository companyRepository;
+
+    public void createAnswer(AnswerDto.AnswerCreateRequest request, String email) {
+        // 기업회원 조회
+        Company company = companyRepository.findByEmail(email)
+                .orElseThrow(() -> new InvalidCustomException(BaseResponseStatus.QNA_ANSWERS_FAIL));
+
+        // 문의 조회
+        Question question = questionRepository.findById(request.getQuestionIdx())
+                .orElseThrow(() -> new InvalidCustomException(BaseResponseStatus.QNA_ANSWER_FAIL_NOT_FOUND));
+
+        // 해당 문의가 달린 게시글(ProductBoard)을 조회
+        ProductBoard productBoard = question.getProductBoard();
+
+        // 기업회원이 이 게시글(ProductBoard)의 작성자인지 확인
+        if (!productBoard.getCompany().getEmail().equals(company.getEmail())) {
+            throw new InvalidCustomException(BaseResponseStatus.FAIL_UNAUTHORIZED);
+        }
+
+        // 답변 생성 및 저장
+        Answer answer = request.toEntity(company, question);
+        answerRepository.save(answer);
+
+        // 문의 상태를 "답변 완료"로 변경
+        question.markAsAnswered();
+        questionRepository.save(question);
+    }
 }

--- a/backend/src/main/java/org/example/backend/domain/qna/service/AnswerService.java
+++ b/backend/src/main/java/org/example/backend/domain/qna/service/AnswerService.java
@@ -23,42 +23,31 @@ public class AnswerService {
     private final CompanyRepository companyRepository;
 
     public void createAnswer(AnswerDto.AnswerCreateRequest request, String email) {
-        // 기업회원 조회
         Company company = companyRepository.findByEmail(email)
                 .orElseThrow(() -> new InvalidCustomException(BaseResponseStatus.QNA_ANSWERS_FAIL));
 
-        // 문의 조회
         Question question = questionRepository.findById(request.getQuestionIdx())
                 .orElseThrow(() -> new InvalidCustomException(BaseResponseStatus.QNA_ANSWER_FAIL_NOT_FOUND));
 
-        // 해당 문의가 달린 게시글(ProductBoard)을 조회
-        ProductBoard productBoard = question.getProductBoard();
-
-        // 기업회원이 이 게시글(ProductBoard)의 작성자인지 확인
-        if (!productBoard.getCompany().getEmail().equals(company.getEmail())) {
+        if (!question.getProductBoard().getCompany().getEmail().equals(company.getEmail())) {
             throw new InvalidCustomException(BaseResponseStatus.FAIL_UNAUTHORIZED);
         }
 
-        // 답변 생성 및 저장
         Answer answer = request.toEntity(company, question);
         answerRepository.save(answer);
 
-        // 문의 상태를 "답변 완료"로 변경
         question.markAsAnswered();
         questionRepository.save(question);
     }
 
     public void deleteAnswer(Long answerIdx, String email) {
-        // 답변 조회
         Answer answer = answerRepository.findById(answerIdx)
                 .orElseThrow(() -> new InvalidCustomException(BaseResponseStatus.QNA_ANSWER_FAIL_NOT_FOUND));
 
-        // 기업회원이 답변을 작성한 사람이 맞는지 확인
         if (!answer.getCompany().getEmail().equals(email)) {
             throw new InvalidCustomException(BaseResponseStatus.FAIL_UNAUTHORIZED);
         }
 
-        // 답변 삭제
         answerRepository.delete(answer);
     }
 }

--- a/backend/src/main/java/org/example/backend/domain/qna/service/AnswerService.java
+++ b/backend/src/main/java/org/example/backend/domain/qna/service/AnswerService.java
@@ -47,4 +47,18 @@ public class AnswerService {
         question.markAsAnswered();
         questionRepository.save(question);
     }
+
+    public void deleteAnswer(Long answerIdx, String email) {
+        // 답변 조회
+        Answer answer = answerRepository.findById(answerIdx)
+                .orElseThrow(() -> new InvalidCustomException(BaseResponseStatus.QNA_ANSWER_FAIL_NOT_FOUND));
+
+        // 기업회원이 답변을 작성한 사람이 맞는지 확인
+        if (!answer.getCompany().getEmail().equals(email)) {
+            throw new InvalidCustomException(BaseResponseStatus.FAIL_UNAUTHORIZED);
+        }
+
+        // 답변 삭제
+        answerRepository.delete(answer);
+    }
 }

--- a/backend/src/main/java/org/example/backend/domain/qna/service/QuestionService.java
+++ b/backend/src/main/java/org/example/backend/domain/qna/service/QuestionService.java
@@ -8,6 +8,7 @@ import org.example.backend.domain.qna.model.entity.Question;
 import org.example.backend.domain.qna.repository.QuestionRepository;
 import org.example.backend.domain.user.model.entity.User;
 import org.example.backend.domain.user.repository.UserRepository;
+import org.example.backend.global.common.constants.AnswerStatus;
 import org.example.backend.global.common.constants.BaseResponseStatus;
 import org.example.backend.global.exception.InvalidCustomException;
 import org.springframework.stereotype.Service;
@@ -38,6 +39,7 @@ public class QuestionService {
 
         // 문의 등록 후 사용자 이름, 답변 상태, 등록 날짜 함께 반환
         return QuestionDto.QuestionCreateResponse.builder()
+                .idx(question.getIdx())
                 .title(question.getTitle())
                 .content(question.getContent())
                 .userName(user.getName())  // 사용자 이름 반환
@@ -48,12 +50,31 @@ public class QuestionService {
     public List<QuestionDto.QuestionListResponse> getQuestions() {
         return questionRepository.findAll().stream()
                 .map(question -> QuestionDto.QuestionListResponse.builder()
+                        .idx(question.getIdx())
                         .title(question.getTitle())
                         .content(question.getContent())
                         .userName(question.getUser().getName())  // 사용자 이름
                         .answerStatus(question.getAnswerStatus())  // 답변 상태
                         .createdAt(question.getCreatedAt())  // 생성일
+                        .email(question.getUser().getEmail())
                         .build())
                 .collect(Collectors.toList());
+    }
+    public void deleteQuestion(Long questionId, String email){
+        Question question = questionRepository.findById(questionId)
+                .orElseThrow(() -> new InvalidCustomException(BaseResponseStatus.QNA_ANSWER_DELETE_FAIL_NOT_FOUND));
+
+        // 문의 작성자와 로그인된 사용자의 이메일이 동일한지 확인
+        if (!question.getUser().getEmail().equals(email)) {
+            throw new InvalidCustomException(BaseResponseStatus.FAIL_UNAUTHORIZED);
+        }
+
+        // 답변 상태가 "답변대기"인지 확인
+        if (!question.getAnswerStatus().equals(AnswerStatus.ANSWER_WAITING.getStatus())) {
+            throw new InvalidCustomException(BaseResponseStatus.QNA_ANSWER_DELETE_FAIL);
+        }
+
+        // 삭제 처리
+        questionRepository.delete(question);
     }
 }

--- a/backend/src/main/java/org/example/backend/domain/qna/service/QuestionService.java
+++ b/backend/src/main/java/org/example/backend/domain/qna/service/QuestionService.java
@@ -97,4 +97,36 @@ public class QuestionService {
         // 삭제 처리
         questionRepository.delete(question);
     }
+
+    public List<QuestionDto.QuestionListResponse> getQuestionsByCompanyEmail(String companyEmail) {
+        List<ProductBoard> productBoards = productBoardRepository.findByCompanyEmail(companyEmail);
+
+        return questionRepository.findByProductBoardIn(productBoards).stream()
+                .map(question -> {
+                    List<Answer> answers = answerRepository.findAllByQuestionIdx(question.getIdx());
+
+                    // 답변 리스트를 응답 DTO로 변환
+                    List<AnswerDto.AnswerResponse> answerResponses = answers.stream()
+                            .map(answer -> AnswerDto.AnswerResponse.builder()
+                                    .idx(answer.getIdx())
+                                    .content(answer.getContent())
+                                    .companyName(answer.getCompany().getName())
+                                    .createdAt(answer.getCreatedAt())
+                                    .build())
+                            .collect(Collectors.toList());
+
+                    return QuestionDto.QuestionListResponse.builder()
+                            .idx(question.getIdx())
+                            .title(question.getTitle())
+                            .content(question.getContent())
+                            .userName(question.getUser().getName())
+                            .answerStatus(question.getAnswerStatus())
+                            .createdAt(question.getCreatedAt())
+                            .email(question.getUser().getEmail())
+                            .productBoardIdx(question.getProductBoard().getIdx())
+                            .answers(answerResponses)
+                            .build();
+                })
+                .collect(Collectors.toList());
+    }
 }

--- a/backend/src/main/java/org/example/backend/domain/qna/service/QuestionService.java
+++ b/backend/src/main/java/org/example/backend/domain/qna/service/QuestionService.java
@@ -41,45 +41,14 @@ public class QuestionService {
         Question question = request.toEntity(user, productBoard);
         questionRepository.save(question);
 
-        // 문의 등록 후 사용자 이름, 답변 상태, 등록 날짜 함께 반환
-        return QuestionDto.QuestionCreateResponse.builder()
-                .idx(question.getIdx())
-                .title(question.getTitle())
-                .content(question.getContent())
-                .userName(user.getName())  // 사용자 이름 반환
-                .answerStatus(question.getAnswerStatus())  // 답변 상태 반환
-                .createdAt(question.getCreatedAt())  // 생성 날짜 반환
-                .build();
+        return question.toCreateResponse();  // 엔티티의 변환 메서드 사용
     }
     public List<QuestionDto.QuestionListResponse> getQuestions() {
         return questionRepository.findAll().stream()
-                .map(question -> {
-                    // 해당 문의에 대한 답변 리스트 조회
-                    List<Answer> answers = answerRepository.findAllByQuestionIdx(question.getIdx());
-
-                    // 답변 리스트를 응답 DTO로 변환
-                    List<AnswerDto.AnswerResponse> answerResponses = answers.stream()
-                            .map(answer -> AnswerDto.AnswerResponse.builder()
-                                    .idx(answer.getIdx())
-                                    .content(answer.getContent())
-                                    .companyName(answer.getCompany().getName())
-                                    .createdAt(answer.getCreatedAt())
-                                    .build())
-                            .collect(Collectors.toList());
-
-                    return QuestionDto.QuestionListResponse.builder()
-                            .idx(question.getIdx())
-                            .title(question.getTitle())
-                            .content(question.getContent())
-                            .userName(question.getUser().getName())  // 사용자 이름
-                            .answerStatus(question.getAnswerStatus())  // 답변 상태
-                            .createdAt(question.getCreatedAt())  // 문의 생성일
-                            .email(question.getUser().getEmail())  // 작성자 이메일
-                            .answers(answerResponses)  // 답변 리스트 추가
-                            .build();
-                })
+                .map(Question::toListResponse)  // 엔티티의 변환 메서드 사용
                 .collect(Collectors.toList());
     }
+
     public void deleteQuestion(Long questionId, String email){
         Question question = questionRepository.findById(questionId)
                 .orElseThrow(() -> new InvalidCustomException(BaseResponseStatus.QNA_ANSWER_DELETE_FAIL_NOT_FOUND));
@@ -102,31 +71,7 @@ public class QuestionService {
         List<ProductBoard> productBoards = productBoardRepository.findByCompanyEmail(companyEmail);
 
         return questionRepository.findByProductBoardIn(productBoards).stream()
-                .map(question -> {
-                    List<Answer> answers = answerRepository.findAllByQuestionIdx(question.getIdx());
-
-                    // 답변 리스트를 응답 DTO로 변환
-                    List<AnswerDto.AnswerResponse> answerResponses = answers.stream()
-                            .map(answer -> AnswerDto.AnswerResponse.builder()
-                                    .idx(answer.getIdx())
-                                    .content(answer.getContent())
-                                    .companyName(answer.getCompany().getName())
-                                    .createdAt(answer.getCreatedAt())
-                                    .build())
-                            .collect(Collectors.toList());
-
-                    return QuestionDto.QuestionListResponse.builder()
-                            .idx(question.getIdx())
-                            .title(question.getTitle())
-                            .content(question.getContent())
-                            .userName(question.getUser().getName())
-                            .answerStatus(question.getAnswerStatus())
-                            .createdAt(question.getCreatedAt())
-                            .email(question.getUser().getEmail())
-                            .productBoardIdx(question.getProductBoard().getIdx())
-                            .answers(answerResponses)
-                            .build();
-                })
+                .map(Question::toListResponse)  // 엔티티의 변환 메서드 사용
                 .collect(Collectors.toList());
     }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -85,7 +85,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #45, #47

<br>
 

## 📝 작업 내용

> 업체 회원이 1:1 문의 관리 페이지에서 자신이 등록한 게시글의 문의 목록을 확인하고, 답변을 등록/삭제할 수 있는 기능을 구현했습니다.

1. 문의 목록 조회 API 구현
- 업체 회원이 자신의 게시글에 달린 문의 목록을 조회할 수 있는 엔드포인트를 구현
- ProductBoard와 Question 엔티티 간 연관관계를 설정하여, 로그인된 업체 회원의 이메일을 통해 해당 업체가 작성한 게시글에 달린 문의들을 조회할 수 있도록 처리
- 이 API는 기업 회원의 이메일을 기반으로, 해당 회원이 작성한 모든 게시글에 대해 문의 목록을 반환

2. 답변 등록 API 구현
- 선택한 문의에 대해 답변을 등록할 수 있는 엔드포인트를 구현
- 요청으로 전달된 문의 idx에 매핑된 Question 엔티티에 답변을 추가하고, 답변이 등록되면 문의의 상태(answerStatus)를 '답변 완료'로 변경하도록 처리
- 등록된 답변은 Answer 엔티티로 저장되며, Question과 연관된 상태로 관리
3. 답변 목록 조회 API 구현
- 특정 문의에 달린 모든 답변을 조회할 수 있는 엔드포인트를 구현
- Question 엔티티와 연관된 답변 목록을 반환하며, 답변 등록 시간 순으로 정렬된 데이터를 제공
4. 답변 삭제 API 구현
- 등록된 답변을 삭제할 수 있는 API를 구현

<br>

## **💬 리뷰 요구사항(선택)**

> 기업 회원으로 로그인한 후, `/qna/company/list` 경로에서 `frontend/feature/company/qna-register` 브랜치와 함께 테스트 부탁합니다.
(만약 DB에 문의 데이터가 없다면, 일반 회원으로 로그인 후 `/board/detail/1` 경로의 '문의' 탭에서 문의를 등록한 뒤 위 테스트를 진행해주세요!)

- [ ] `/qna/company/list` 경로에 접속했을 때 문의 목록이 정상적으로 표시되는지
- [ ] `✎` 아이콘을 클릭했을 때 답변 등록 모달 창이 뜨고, 모달 창에 해당 문의가 달린 게시글의 이름과 문의 제목, 내용이 자동으로 세팅되어 있는지
- [ ] 답변을 입력하고 `등록` 버튼을 클릭했을 때 DB에 답변이 정상적으로 저장되는지
- [ ] 답변 확인 모달 창에서 `X` 아이콘을 눌렀을 때 답변 목록이 정상적으로 표시되는지
- [ ] 답변 목록에서 `삭제` 버튼을 눌렀을 때 해당 답변이 화면에서 사라지고, DB에도 삭제가 반영되는지 확인 부탁드립니다 :)
