### PR TITLE
[#79, #91, #189, #217] 1:1 문의 관리 기능 구현, 내 문의 기능 구현, 문의 삭제 기능 구현, 문의 수정 기능 구현

### DIFF
--- a/frontend/src/components/board/BoardDetailNavComponent.vue
+++ b/frontend/src/components/board/BoardDetailNavComponent.vue
@@ -264,6 +264,7 @@ export default {
         this.qnaStore.updateInquiry(this.editingIndex, updatedInquiry);
         this.localTableData[this.editingIndex] = { ...this.localTableData[this.editingIndex], ...updatedInquiry };  // 바로 반영
         this.editingIndex = null;
+        this.loadInquiries();
         this.closeModal();
       }
       this.qnaStore.fetchInquiries().then(() => {

--- a/frontend/src/components/board/BoardDetailNavComponent.vue
+++ b/frontend/src/components/board/BoardDetailNavComponent.vue
@@ -123,8 +123,9 @@
 
     <!-- 수정 모달 -->
     <QnaRegisterModalComponent v-if="showEditInquiryModal" :initialSubject="selectedInquiry.title"
-      :initialContent="selectedInquiry.content" @close="closeModal" @submit="updateInquiry" :isEditMode="true"
-      :productBoardIdx="productBoardIdx" :thumbnail="thumbnails[0]" :title="productTitle" />
+      :initialContent="selectedInquiry.content" :inquiryId="selectedInquiry.idx" @close="closeModal"
+      @submit="updateInquiry" :isEditMode="true" :productBoardIdx="productBoardIdx" :thumbnail="thumbnails[0]"
+      :title="productTitle" />
   </div>
 </template>
 
@@ -214,8 +215,9 @@ export default {
       this.showNewInquiryModal = true;
     },
     openEditModal(index) {
-      this.selectedInquiry = { ...this.localTableData[index] }; // 선택한 문의 데이터를 저장
-      this.editingIndex = index; // 수정할 문의의 인덱스를 저장
+      const selectedInquiry = { ...this.localTableData[index] }; // 선택한 문의 데이터를 저장
+      this.selectedInquiry = selectedInquiry;
+      this.editingIndex = index;
       this.showEditInquiryModal = true;
     },
     closeModal() {
@@ -683,6 +685,7 @@ div {
   border: 0px;
   background: none;
   color: rgb(153, 153, 153);
+  margin-bottom: 5px;
 }
 
 .css-1ankuif::before {

--- a/frontend/src/components/board/BoardDetailNavComponent.vue
+++ b/frontend/src/components/board/BoardDetailNavComponent.vue
@@ -199,7 +199,7 @@ export default {
         .finally(() => {
           // 회원정보 조회에 성공하든 실패하든 문의 목록은 조회하도록
           this.qnaStore.fetchInquiries().then(() => {
-            this.localTableData = this.qnaStore.inquiries;
+          this.localTableData = this.qnaStore.inquiries.filter(inquiry => inquiry.productBoardIdx === this.productBoardIdx);
           });
         });
     },
@@ -685,7 +685,6 @@ div {
   border: 0px;
   background: none;
   color: rgb(153, 153, 153);
-  margin-bottom: 5px;
 }
 
 .css-1ankuif::before {

--- a/frontend/src/components/board/BoardDetailNavComponent.vue
+++ b/frontend/src/components/board/BoardDetailNavComponent.vue
@@ -22,11 +22,7 @@
     </nav>
     <!-- 상품 상세 설명 section -->
     <div class="css-0 el27cq1">
-      <div
-        id="description"
-        class="css-18eozqj el27cq0"
-        v-show="activeTab === 'description'"
-      >
+      <div id="description" class="css-18eozqj el27cq0" v-show="activeTab === 'description'">
         <div class="css-1d3w5wq e1d86arr0">
           <div class="css-1lyi66c">
             <div class="goods_wrap">
@@ -48,13 +44,7 @@
     <!-- 문의 하기 리스트 section -->
     <div class="css-30tvht eewa3w91" v-show="activeTab === 'inquiries'">
       <div class="css-17juoyc eewa3w90">
-        <button
-          class="css-mhrz8m e4nu7ef3"
-          type="button"
-          width="120"
-          height="40"
-          @click="openNewInquiryModal"
-        >
+        <button class="css-mhrz8m e4nu7ef3" type="button" width="120" height="40" @click="openNewInquiryModal">
           <span class="css-nytqmg e4nu7ef1">문의하기</span>
         </button>
       </div>
@@ -85,17 +75,14 @@
             </td>
             <td class="css-1pkqelu e1l5ky7y6">
               {{
-                row.modifiedAt
-                  ? formatDate(row.modifiedAt)
-                  : formatDate(row.createdAt)
+              row.modifiedAt
+              ? formatDate(row.modifiedAt)
+              : formatDate(row.createdAt)
               }}
             </td>
             <td class="css-bhr3cq e1l5ky7y5">{{ row.answerStatus }}</td>
           </tr>
-          <tr
-            v-show="expandedInquiryIndex === index"
-            class="css-1mvq381 e61d7mt0"
-          >
+          <tr v-show="expandedInquiryIndex === index" class="css-1mvq381 e61d7mt0">
             <td colspan="4">
               <div class="css-tnubsz e1ptpt003">
                 <div class="css-1n83etr e1ptpt002">
@@ -131,23 +118,13 @@
     </div>
 
     <!-- 새 문의 작성 모달 -->
-    <QnaRegisterModalComponent
-      v-if="showNewInquiryModal"
-      @close="closeModal"
-      @submit="addNewInquiry"
-      :productBoardIdx="productBoardIdx"
-      :thumbnail="thumbnails[0]"
-      :title="productTitle"
-    />
+    <QnaRegisterModalComponent v-if="showNewInquiryModal" @close="closeModal" @submit="addNewInquiry"
+      :isEditMode="false" :productBoardIdx="productBoardIdx" :thumbnail="thumbnails[0]" :title="productTitle" />
 
     <!-- 수정 모달 -->
-    <QnaRegisterModalComponent
-      v-if="showEditInquiryModal"
-      :initialSubject="selectedInquiry.title"
-      :initialContent="selectedInquiry.content"
-      @close="closeModal"
-      @submit="updateInquiry"
-    />
+    <QnaRegisterModalComponent v-if="showEditInquiryModal" :initialSubject="selectedInquiry.title"
+      :initialContent="selectedInquiry.content" @close="closeModal" @submit="updateInquiry" :isEditMode="true"
+      :productBoardIdx="productBoardIdx" :thumbnail="thumbnails[0]" :title="productTitle" />
   </div>
 </template>
 

--- a/frontend/src/components/board/BoardDetailNavComponent.vue
+++ b/frontend/src/components/board/BoardDetailNavComponent.vue
@@ -139,10 +139,18 @@ import axios from "axios";
 export default {
   name: "BoardDetailNavComponent",
   computed: {
-    ...mapStores(useQnaStore, useUserStore),
-    userEmail() {
-      return this.userStore.userDetail.email || "email 세팅 안 됨";
-    },
+  ...mapStores(useQnaStore, useUserStore),
+  userEmail() {
+    return this.userStore.userDetail.email || "email 세팅 안 됨";
+  },
+  userType() {
+    if (this.userStore.roles.includes("ROLE_USER")) {
+      return "ROLE_USER";
+    } else if (this.userStore.roles.includes("ROLE_COMPANY")) {
+      return "ROLE_COMPANY";
+    }
+    return null; // roles 값이 없으면 null 반환
+    }
   },
   props: {
     thumbnails: {
@@ -206,10 +214,12 @@ export default {
       return date.toLocaleDateString("ko-KR", { year: "numeric", month: "2-digit", day: "2-digit" });
     },
     openNewInquiryModal() {
-      if (this.userStore.isLogined) {
-        this.showNewInquiryModal = true;
-      } else {
+      if (!this.userStore.isLogined) {
         alert("로그인 후 이용해주세요.");
+      } else if (this.userType === "ROLE_COMPANY") {
+        alert("일반회원만 문의 가능합니다.");
+      } else if (this.userType === "ROLE_USER") {
+        this.showNewInquiryModal = true;
       }
     },
     openEditModal(index) {
@@ -698,4 +708,5 @@ div {
   object-fit: contain; /* 비율을 유지하면서 영역에 맞게 이미지 표시 */
 }
 </style>
+
 

--- a/frontend/src/components/board/BoardDetailNavComponent.vue
+++ b/frontend/src/components/board/BoardDetailNavComponent.vue
@@ -93,7 +93,7 @@
                     <span>{{ row.content }}<br /></span>
                   </div>
                 </div>
-                <div class="css-1j49yxi e11ufodi1" v-if="row.answerStatus === '답변대기' && row.email === this.userEmail">
+                <div class="css-1j49yxi e11ufodi1" v-if="row.answerStatus === '답변대기' && row.email === this.userEmail && this.userType === 'ROLE_USER'">
                   <button type=" button" @click="openEditModal(index)">수정</button>
                   <button type="button" class="css-1ankuif e11ufodi0" @click="deleteInquiry(row.idx, index)">삭제</button>
                 </div>

--- a/frontend/src/components/board/BoardDetailNavComponent.vue
+++ b/frontend/src/components/board/BoardDetailNavComponent.vue
@@ -206,7 +206,11 @@ export default {
       return date.toLocaleDateString("ko-KR", { year: "numeric", month: "2-digit", day: "2-digit" });
     },
     openNewInquiryModal() {
-      this.showNewInquiryModal = true;
+      if (this.userStore.isLogined) {
+        this.showNewInquiryModal = true;
+      } else {
+        alert("로그인 후 이용해주세요.");
+      }
     },
     openEditModal(index) {
       const selectedInquiry = { ...this.localTableData[index] }; // 선택한 문의 데이터를 저장
@@ -239,8 +243,11 @@ export default {
     },
     addNewInquiry(newInquiry) {
       this.qnaStore.addInquiry(newInquiry);
-      this.localTableData = [...this.localTableData, newInquiry]; // 화면에 바로 반영
+      //this.localTableData = [...this.localTableData, newInquiry]; // 화면에 바로 반영
       this.closeModal();
+      this.qnaStore.fetchInquiries().then(() => {
+            this.localTableData = [...this.qnaStore.inquiries.filter(inquiry => inquiry.productBoardIdx === this.productBoardIdx)];
+          });
     },
     updateInquiry(updatedInquiry) {
       if (this.editingIndex !== null) {

--- a/frontend/src/components/board/BoardDetailNavComponent.vue
+++ b/frontend/src/components/board/BoardDetailNavComponent.vue
@@ -105,9 +105,7 @@
                   </div>
                   <div class="css-1bv2zte e1ptpt000">
                     <div>{{ answer.content }}</div>
-                  </div>
-                  <div class="css-17g9jzg e1gk8zam0">
-                    {{ answer.createdAt ? formatDate(answer.createdAt) : '작성 시간 없음' }}
+                    <div class="css-17g9jzg e1gk8zam0 answer-date-left">{{ answer.createdAt ? formatDate(answer.createdAt) : '작성 시간 없음' }}</div>
                   </div>
                 </div>
               </div>
@@ -407,6 +405,19 @@ export default {
 
 
 <style scoped>
+.author {
+  width: 150px; /* 원하는 고정 너비로 설정 */
+  text-align: center; /* 내용 가운데 정렬 */
+}
+
+.created-date {
+  width: 150px; /* 헤더 셀에도 동일한 고정 너비 적용 */
+}
+
+.status {
+  width: 150px; /* 본문 셀에도 동일한 고정 너비 적용 */
+}
+
 .pagination {
   display: flex;
   justify-content: center;
@@ -803,6 +814,7 @@ tr {
 }
 
 .css-1brd6ns {
+  max-width: 250px;
   text-align: left;
   padding: 0px 20px;
   cursor: pointer;
@@ -856,6 +868,7 @@ div {
 }
 
 .css-1bv2zte {
+
   margin-left: 12px;
   padding-top: 2px;
   font-size: 14px;
@@ -874,8 +887,6 @@ div {
 }
 
 .css-17g9jzg {
-  padding: 0px 16px 20px;
-  margin-left: 40px;
   font-size: 14px;
   line-height: 22px;
   color: rgb(153, 153, 153);
@@ -913,6 +924,12 @@ div {
   width: 1050px;
   height: auto; /* 이미지 비율에 맞게 자동으로 높이 설정 */
   object-fit: contain; /* 비율을 유지하면서 영역에 맞게 이미지 표시 */
+}
+
+.answer-date-left {
+  text-align: left; /* 날짜를 왼쪽 정렬 */
+  margin-top: 8px; /* 답변 내용과 날짜 사이 간격 추가 */
+  color: rgb(153, 153, 153); /* 날짜 텍스트 색상 */
 }
 </style>
 

--- a/frontend/src/components/company/CompanyAnswerListModalComponent.vue
+++ b/frontend/src/components/company/CompanyAnswerListModalComponent.vue
@@ -4,10 +4,10 @@
             <span class="close" @click="closeModal">&times;</span>
             <div class="answer-list-modal">
                 <h3>답변 목록</h3>
-                <ul>
-                    <li v-for="answer in selectedInquiry.answers || []" :key="answer.idx">
-                        <div class="answer-item">
-                            <p class="answer-content">{{ answer.content }}</p>
+                <ul v-if="selectedInquiry.answers && selectedInquiry.answers.length > 0">
+                    <li v-for="(answer, index) in selectedInquiry.answers" :key="index">
+                        <div v-if="answer" class="answer-item">
+                            <p class="answer-content">{{ answer.content || '아직 답변이 없습니다.' }}</p>
                             <div class="answer-footer">
                                 <span class="answer-date">{{ formatDate(answer.createdAt) }}</span>
                                 <button class="delete-button" @click="deleteAnswer(answer.idx)">삭제</button>
@@ -149,3 +149,4 @@ export default {
     background-color: #5f0080;
 }
 </style>
+

--- a/frontend/src/components/company/CompanyAnswerListModalComponent.vue
+++ b/frontend/src/components/company/CompanyAnswerListModalComponent.vue
@@ -39,9 +39,19 @@ export default {
             this.$emit("closeModal");
         },
         async deleteAnswer(answerId) {
-            try {
-                await axios.delete(`/api/qna/answer/delete/${answerId}`);
-                this.$emit("answerDeleted", answerId);
+    try {
+        await axios.delete(`/api/qna/answer/delete/${answerId}`);
+        
+        const updatedAnswers = this.selectedInquiry.answers.filter(answer => answer.idx !== answerId);
+
+        // 남은 답변이 없으면 상태를 '답변대기'로 변경
+        const updatedStatus = updatedAnswers.length === 0 ? '답변대기' : this.selectedInquiry.answerStatus;
+
+        // 부모 컴포넌트에게 상태 업데이트 요청
+        this.$emit("answerDeleted", answerId, {
+            answers: updatedAnswers,
+            answerStatus: updatedStatus,
+            });
             } catch (error) {
                 console.error("답변 삭제 실패:", error);
             }

--- a/frontend/src/components/company/CompanyQnAManageComponent.vue
+++ b/frontend/src/components/company/CompanyQnAManageComponent.vue
@@ -9,7 +9,7 @@
           <th class="tit_status">상태</th>
           <th class="tit_date">문의 등록일</th>
           <th class="tit_write">답변등록</th>
-          <th class="tit_delete">답변확인</th>
+          <th class="tit_delete">답변목록</th>
         </tr>
       </thead>
       <tbody id="addrList">
@@ -288,6 +288,31 @@ export default {
 
 
 <style scoped>
+.tit_title{
+  width: 310px;
+}
+
+.tit_name {
+  width: 75px; /* 원하는 고정 너비로 설정 */
+  text-align: center; /* 내용 가운데 정렬 */
+}
+
+.tit_status {
+  width: 75px; /* 헤더 셀에도 동일한 고정 너비 적용 */
+}
+
+.tit_date {
+  width: 75px; /* 본문 셀에도 동일한 고정 너비 적용 */
+}
+
+.tit_write{
+  width: 50px;
+}
+
+.tit_delete{
+  width: 50px;
+}
+
 .pagination {
   display: flex;
   justify-content: center;
@@ -538,8 +563,8 @@ div {
   width: 24px;
   height: 24px;
   border: 0 none;
-  background: url(https://res.kurly.com/pc/service/cart/2007/ico_delete.svg)
-    no-repeat 50% 50%;
+  background: url('@/assets/arrow.png') no-repeat 50% 50%;
+  background-size: contain;
   font-size: 0;
   line-height: 0;
   top: 33px;
@@ -553,6 +578,17 @@ div {
   font-size: 15px;
   color: #757575;
   text-align: center;
+}
+
+.title {
+  text-align: left !important; /* 강제로 왼쪽 정렬 */
+  padding-left: 30px; /* 왼쪽에 여유 공간 추가 */
+  padding-right: 30px;
+}
+
+.addr {
+  text-align: left !important; /* 내부 텍스트도 강제로 왼쪽 정렬 */
+  padding-left: 10px; /* 왼쪽에 여유 공간 추가 */
 }
 </style>
 

--- a/frontend/src/components/company/CompanyQnAManageComponent.vue
+++ b/frontend/src/components/company/CompanyQnAManageComponent.vue
@@ -135,8 +135,15 @@ export default {
       this.selectedInquiry = null;
       this.isDisplayAnswerListModal = false;
     },
-    removeAnswerFromList(answerId) {
-      this.selectedInquiry.answers = this.selectedInquiry.answers.filter(answer => answer.idx !== answerId);
+    removeAnswerFromList(answerId, updatedInquiry) {
+      // 부모 컴포넌트에서 상태를 관리하므로, 여기서 상태를 업데이트합니다.
+      this.selectedInquiry.answers = updatedInquiry.answers;
+
+      if (this.selectedInquiry.answers.length === 0) {
+        this.selectedInquiry.answerStatus = '답변대기';
+      }
+
+      // 전체 문의 목록에서도 해당 문의의 상태를 업데이트할 수 있습니다.
     },
     async deleteInquiry(inquiryId) {
       try {

--- a/frontend/src/components/company/CompanyQnAModalComponent.vue
+++ b/frontend/src/components/company/CompanyQnAModalComponent.vue
@@ -127,17 +127,23 @@ export default {
       this.isRegisterDisabled = this.textareaContent.trim() === "";
     },
     async registerAnswer() {
-      try {
-        // 답변 등록 API 호출
-        const response = await axios.post("/api/qna/answer/create", {
-          questionIdx: this.questionIdx,  // 문의 ID 전달
-          content: this.textareaContent,  // 답변 내용 전달
-        });
-        const newAnswer = response.data.result;  // 서버에서 응답 받은 새 답변
-        this.$emit("registerAnswer", newAnswer); // 부모 컴포넌트로 새 답변 전달
-        this.closeModal();
+    try {
+      // 답변 등록 API 호출
+      const response = await axios.post("/api/qna/answer/create", {
+        questionIdx: this.questionIdx,  // 문의 ID 전달
+        content: this.textareaContent,  // 답변 내용 전달
+      });
+      const newAnswer = response.data.result;  // 서버에서 응답 받은 새 답변
+      this.$emit("registerAnswer", newAnswer); // 부모 컴포넌트로 새 답변 전달
+
+      // 등록된 답변을 selectedInquiry의 answers에 추가
+      if (this.selectedInquiry && Array.isArray(this.selectedInquiry.answers)) {
+        this.selectedInquiry.answers.push(newAnswer);
+      }
+      
+      this.closeModal();  // 모달 닫기
       } catch (error) {
-        console.error("답변 등록 실패:", error);
+      console.error("답변 등록 실패:", error);
       }
     },
   },
@@ -615,3 +621,4 @@ textarea {
   text-align: left;
 } */
 </style>
+

--- a/frontend/src/components/mypage/MypageQnAComponent.vue
+++ b/frontend/src/components/mypage/MypageQnAComponent.vue
@@ -530,7 +530,7 @@ img {
 
 /* Flex 속성으로 답변을 가로로 나열 */
 .horizontal-answers {
-    display: flex;
+    display: block;
     flex-direction: row;
     flex-wrap: wrap;
     gap: 20px;
@@ -538,8 +538,7 @@ img {
 }
 
 .answer-section {
-    flex: 1 1 auto;
-    min-width: 200px;
+    width: 100%; /* 한 줄에 하나씩 답변이 나열되도록 설정 */
 }
 
 .answer-content {

--- a/frontend/src/components/qna/QnaRegisterModalComponent.vue
+++ b/frontend/src/components/qna/QnaRegisterModalComponent.vue
@@ -157,6 +157,7 @@ export default {
         async submitForm() {
             // 문의 수정 또는 등록 로직
             const inquiryData = {
+                idx: this.inquiryId,  // 수정 시 ID 전달
                 title: this.subject,
                 content: this.content,
                 productBoardIdx: this.productBoardIdx,
@@ -167,15 +168,13 @@ export default {
                     // 수정 모드일 때 PUT 요청
                     const response = await axios.put(`/api/qna/question/update/${this.inquiryId}`, inquiryData);
                     if (response.data.isSuccess) {
-                        this.qnaStore.updateInquiry(response.data.result);
-                        this.$emit("submit", response.data.result); // 부모 컴포넌트에 수정된 데이터를 전달
+                        this.$emit("submit", inquiryData); // 부모 컴포넌트에 수정된 데이터를 전달
                     }
                 } else {
                     // 등록 모드일 때 POST 요청
                     const response = await axios.post('/api/qna/question/create', inquiryData);
                     if (response.data.isSuccess) {
-                        this.qnaStore.addInquiry(response.data.result);
-                        this.$emit("submit", response.data.result); // 부모 컴포넌트에 등록된 데이터를 전달
+                        this.$emit("submit", inquiryData); // 부모 컴포넌트에 등록된 데이터를 전달
                     }
                 }
                 this.closeModal();

--- a/frontend/src/components/qna/QnaRegisterModalComponent.vue
+++ b/frontend/src/components/qna/QnaRegisterModalComponent.vue
@@ -10,7 +10,7 @@
                 <div class="MuiDialogContent-root css-ew9uri">
                     <div class="css-190e3ze eg43r0m0">
                         <div class="css-1c7i6of et95tiw2">
-                            <div class="css-1d3g9q7 et95tiw1">상품 문의하기</div>
+                            <div class="css-1d3g9q7 et95tiw1">{{ isEditMode ? '문의 수정하기' : '상품 문의하기' }}</div>
                             <span class="css-e50sj0 et95tiw0" @click="closeModal"></span>
                         </div>
                         <div class="css-1tm481w eell72m3">
@@ -76,7 +76,7 @@
                             </button>
                             <button class="css-f4f4h7 e4nu7ef3" type="button" :disabled="!isFormValid"
                                 @click="submitForm">
-                                <span class="css-nytqmg e4nu7ef1">등록</span>
+                                <span class="css-nytqmg e4nu7ef1">{{ isEditMode ? '수정' : '등록' }}</span>
                             </button>
                         </div>
                     </div>
@@ -96,6 +96,10 @@ import { useUserStore } from "@/stores/useUserStore";  // 사용자 스토어 �
 export default {
     name: "QnaRegisterModalComponent",
     props: {
+        isEditMode: {
+            type: Boolean,
+            default: false
+        },
         initialSubject: {
             type: String,
             default: ""
@@ -271,8 +275,7 @@ th {
 .css-190e3ze {
     display: flex;
     flex-direction: column;
-    width: 800px;
-    height: 620px;
+    width: 700px;
     padding: 30px;
     background: rgb(255, 255, 255);
 }
@@ -344,7 +347,7 @@ video {
 }
 
 .css-1mysn55 {
-    flex: 6.5 1 0%;
+    flex: 4.7 1 0%;
     display: flex;
     -webkit-box-align: center;
     align-items: center;
@@ -418,7 +421,7 @@ video {
     position: relative;
     display: flex;
     flex-direction: column;
-    height: 260px;
+    height: 250px;
     background-color: rgb(255, 255, 255);
     border: 1px solid rgb(221, 221, 221);
     border-radius: 4px;
@@ -525,8 +528,8 @@ ul {
 }
 
 .css-f9c7pn button {
-    width: 160px;
-    height: 56px;
+    width: 110px;
+    height: 45px;
     border-radius: 3px;
 }
 
@@ -562,7 +565,7 @@ ul {
 
 .css-nytqmg {
     display: inline-block;
-    font-size: 16px;
+    font-size: 14px;
     font-weight: 500;
 }
 

--- a/frontend/src/components/qna/QnaRegisterModalComponent.vue
+++ b/frontend/src/components/qna/QnaRegisterModalComponent.vue
@@ -18,7 +18,7 @@
                                 <img :src="thumbnail" class="css-1vpfo16 eell72m1">
                             </div>
                             <div class="css-1mysn55 eell72m0">
-                                <span>{{title}}</span>
+                                <span>{{ title }}</span>
                             </div>
                         </div>
                         <div class="css-4qu8li e43j10r2">

--- a/frontend/src/stores/useQnaStore.js
+++ b/frontend/src/stores/useQnaStore.js
@@ -1,4 +1,3 @@
-
 import { defineStore } from "pinia";
 import axios from "axios";
 
@@ -9,10 +8,9 @@ export const useQnaStore = defineStore("qna", {
     actions: {
         async fetchInquiries() {
             try {
-                const response = await axios.get('/api/qna/question/list'); 
+                const response = await axios.get('/api/qna/question/list');
                 if (response.data.isSuccess) {
                     this.inquiries = response.data.result;
-                    console.log(this.inquiries);
                 } else {
                     console.error('문의 목록을 불러오는 중 오류 발생:', response.data.message);
                 }
@@ -24,14 +22,13 @@ export const useQnaStore = defineStore("qna", {
             this.inquiries.push(newInquiry);
         },
         updateInquiry(index, updatedInquiry) {
-            this.inquiries[index] = { ...this.inquiries[index], ...updatedInquiry };
+            this.inquiries.splice(index, 1, { ...this.inquiries[index], ...updatedInquiry }); // 수정된 문의 반영
         },
         async deleteInquiry(idx, index) {
             try {
-                // console.log('삭제 요청 경로:', `/api/qna/question/delete/${idx}`);
                 const response = await axios.delete(`/api/qna/question/delete/${idx}`);
                 if (response.data.isSuccess) {
-                    this.inquiries.splice(index, 1);  
+                    this.inquiries.splice(index, 1);
                     console.log('문의가 성공적으로 삭제되었습니다.');
                 } else {
                     console.error('문의 삭제 중 오류 발생:', response.data.message);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #79, #91, #189, #217

<br>
 

## 📝 작업 내용
>**문의 수정 관련 기능 추가**
- 문의 수정 모달 UI 수정 및 isEditMode prop 추가 
- 문의 수정 API 연동 및 수정 시 화면에 바로 반영되도록 구현 
- 문의 등록 시 수정/삭제 버튼이 보이지 않는 문제 해결

>**문의 목록 및 답변 관련 기능 추가**
- 특정 게시글에 해당하는 문의만 보이도록 필터링 로직 추가 
- 답변 등록 후 문의 목록이 자동으로 갱신되도록 수정 
- 답변이 모두 삭제되면 문의 상태가 '답변대기'로 즉시 반영되도록 구현
- 동일 이메일을 사용하는 기업 회원에게 수정/삭제 버튼이 보이지 않도록 처리

>**마이페이지 및 문의 관리 기능 개선**
- 마이페이지 문의 목록에 이미지 URL 추가 및 게시글 이동 기능 구현
- 내 문의 목록에서 수정 및 삭제 기능 구현, 수정된 내용이 즉시 반영되도록 처리
- 마이페이지 문의 목록 페이징 처리 추가
- 상품 게시글과 1:1 문의 관리 페이지에서 문의 목록 페이징 처리

>**기타 수정 사항**
- 로그인하지 않은 사용자 및 기업회원의 문의하기 버튼 접근 제어 추가
- 답변 목록 버튼 이미지 변경 및 목록 가로 길이 고정 

<br>

## **💬 리뷰 요구사항(선택)**

> `backend/feature/user/qna/edit` 브랜치와 함께 테스트 부탁드립니다 :)

**공통**
- [ ] 페이징 처리가 제대로 동작하는가
- [ ] 문의 목록이 최신순으로 정렬되는가

**기업회원 1:1 문의 관리 페이지**
- [ ] 답변 삭제 후 상태가 답변대기로 돌아가는가
- [ ] 답변 등록 후 새로고침 없이 답변확인 상태로 화면에 반영되는가
- [ ] 답변 등록 모달창에 문의 사진이 잘 보이는가

**상품 게시글 문의 탭**
- [ ] 일반회원과 기업회원의 이메일이 같은 경우, 일반회원이 남긴 문의에 수정/삭제 버튼이 보이지 않는가
- [ ] 로그인한 일반회원만 문의하기 모달창이 동작하는가
- [ ] 해당 게시글의 문의글만 표시되는가

**마이페이지 문의 탭**
- [ ] 수정/삭제 버튼 및 기능이 제대로 작동하는가

(💡 이번 PR에 여러 가지 작업이 한꺼번에 들어갔는데, 다음부터는 기능 단위로 더 나누어 작업하겠습니다.)
