### PR TITLE
[#43, #255] 상품 문의 삭제 기능 구현, 답변 삭제 시 답변이 없을 경우 '답변대기' 상태로 변경하는 API 수정

### DIFF
--- a/backend/src/main/java/org/example/backend/domain/qna/controller/QuestionController.java
+++ b/backend/src/main/java/org/example/backend/domain/qna/controller/QuestionController.java
@@ -71,4 +71,14 @@ public class QuestionController {
         List<QuestionDto.QuestionListResponse> questionList = questionService.getQuestionsByUserEmail(userEmail);
         return new BaseResponse<>(questionList);
     }
+
+    @Operation(summary = "문의 수정 API", description = "문의 제목과 내용을 수정합니다.")
+    @PutMapping("/update/{id}")
+    public BaseResponse updateQuestion(@PathVariable Long id,
+                                       @RequestBody QuestionDto.QuestionUpdateRequest request,
+                                       @AuthenticationPrincipal UserDetails userDetails) {
+        String email = userDetails.getUsername();
+        questionService.updateQuestion(id, request, email);
+        return new BaseResponse<>(BaseResponseStatus.SUCCESS);
+    }
 }

--- a/backend/src/main/java/org/example/backend/domain/qna/model/dto/QuestionDto.java
+++ b/backend/src/main/java/org/example/backend/domain/qna/model/dto/QuestionDto.java
@@ -73,4 +73,13 @@ public class QuestionDto {
 
         private List<AnswerDto.AnswerResponse> answers;
     }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class QuestionUpdateRequest {
+        private String title;
+        private String content;
+    }
 }

--- a/backend/src/main/java/org/example/backend/domain/qna/model/entity/Question.java
+++ b/backend/src/main/java/org/example/backend/domain/qna/model/entity/Question.java
@@ -99,4 +99,11 @@ public class Question {
         this.content = newContent;
         this.modifiedAt = LocalDateTime.now();  // 문의가 수정될 때만 modifiedAt 갱신
     }
+
+    // 문의 제목과 내용을 수정하는 메서드
+    public void updateContent(String newTitle, String newContent) {
+        this.title = newTitle;
+        this.content = newContent;
+        this.modifiedAt = LocalDateTime.now();  // 수정 시간을 현재 시간으로 업데이트
+    }
 }

--- a/backend/src/main/java/org/example/backend/domain/qna/service/AnswerService.java
+++ b/backend/src/main/java/org/example/backend/domain/qna/service/AnswerService.java
@@ -14,6 +14,8 @@ import org.example.backend.global.common.constants.BaseResponseStatus;
 import org.example.backend.global.exception.InvalidCustomException;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class AnswerService {
@@ -49,5 +51,15 @@ public class AnswerService {
         }
 
         answerRepository.delete(answer);
+
+        // 답변이 남아 있는지 확인
+        Question question = answer.getQuestion();
+        List<Answer> remainingAnswers = answerRepository.findAllByQuestionIdx(question.getIdx());
+
+        if (remainingAnswers.isEmpty()) {
+            // 답변이 없으면 상태를 "답변대기"로 변경
+            question.markAsWaiting();
+            questionRepository.save(question);
+        }
     }
 }

--- a/backend/src/main/java/org/example/backend/domain/qna/service/QuestionService.java
+++ b/backend/src/main/java/org/example/backend/domain/qna/service/QuestionService.java
@@ -84,4 +84,19 @@ public class QuestionService {
                 .map(Question::toListResponse)  // 엔티티의 변환 메서드 사용
                 .collect(Collectors.toList());
     }
+
+    public void updateQuestion(Long id, QuestionDto.QuestionUpdateRequest request, String email) {
+        // 수정할 문의 조회
+        Question question = questionRepository.findById(id)
+                .orElseThrow(() -> new InvalidCustomException(BaseResponseStatus.QNA_QUESTION_UPDATE_FAIL_NOT_FOUND));
+
+        // 문의 작성자와 로그인된 사용자의 이메일이 동일한지 확인
+        if (!question.getUser().getEmail().equals(email)) {
+            throw new InvalidCustomException(BaseResponseStatus.FAIL_UNAUTHORIZED);
+        }
+
+        // 문의 내용 업데이트
+        question.updateContent(request.getTitle(), request.getContent());
+        questionRepository.save(question);  // 수정된 문의 저장
+    }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #43, #225

<br>
 

## 📝 작업 내용

> 문의 수정 API 구현
- `QuestionController`에 문의 수정 API 엔드포인트 추가 (`/update/{id}`)
- 로그인된 사용자만 자신의 문의를 수정할 수 있도록 이메일 비교 로직 추가
- 문의 수정 시 제목과 내용 수정 가능 (`QuestionDto.QuestionUpdateRequest` 클래스 추가)
- 수정 시간(`modifiedAt`)은 수정이 발생할 때 자동으로 업데이트
- 수정 실패 시 적절한 예외 처리 (`QNA_QUESTION_UPDATE_FAIL_NOT_FOUND`, `FAIL_UNAUTHORIZED`)

<br>

## **💬 리뷰 요구사항(선택)**

> `frontend/feature/user/qna-edit` 브랜치와 함께 테스트 부탁드립니다 :)
(기능 동작 요구사항은 #240 요구사항 참고)

