### PR TITLE
[#249] 관심 게시글 표시 유지 기능 구현

### DIFF
--- a/frontend/src/components/board/BoardDetailProductInfoComponent.vue
+++ b/frontend/src/components/board/BoardDetailProductInfoComponent.vue
@@ -247,6 +247,7 @@ export default {
     data: {
       type: Object,
     },
+    productBoardIdx: {},
   },
   data() {
     return {
@@ -280,9 +281,12 @@ export default {
       },
     };
   },
-  // created() {
-  //   this.mapProductsToOptions();
-  // },
+  created() {
+    this.isHeartFilled = this.data.likes;
+    if (this.isHeartFilled) {
+      this.heartImage = this.filledHeartImage;
+    }
+  },
   computed: {
     totalPrice() {
       return this.cartItems.reduce(
@@ -352,7 +356,7 @@ export default {
     },
 
     async toggleHeart() {
-      this.request.productBoardIdx = 1;
+      this.request.productBoardIdx = this.productBoardIdx;
       if (!this.userStore.isLogined) {
         alert("로그인이 필요한 서비스입니다.");
         this.$router.push({

--- a/frontend/src/components/mainpage/MainCardViewComponent.vue
+++ b/frontend/src/components/mainpage/MainCardViewComponent.vue
@@ -157,6 +157,11 @@ export default {
   mounted() {
     this.startTimer();
     this.isActive = this.data.likes;
+    if (this.isActive) {
+      this.heartIcon = heartIconActive;
+    }
+    console.log("likes여부");
+    console.log(this.data.likes);
   },
   beforeUnmount() {
     clearInterval(this.intervalId);

--- a/frontend/src/components/mainpage/MainCardViewComponent.vue
+++ b/frontend/src/components/mainpage/MainCardViewComponent.vue
@@ -204,21 +204,21 @@ export default {
       this.minutes = "00";
       this.seconds = "00";
     },
-  },
-  async toggleHeart() {
-    this.request.productBoardIdx = this.data.idx;
-    console.log(this.data.likes);
-    if (!this.userStore.isLogined) {
-      alert("로그인이 필요한 서비스입니다.");
-      this.$router.push("/auth/login");
-      return;
-    }
-    if (await this.userStore.like(this.request)) {
-      this.isActive = !this.isActive;
-      this.heartIcon = this.isActive ? heartIconActive : heartIcon;
-    } else {
-      alert("관심 등록에 실패했습니다.");
-    }
+    async toggleHeart() {
+      this.request.productBoardIdx = this.data.idx;
+      console.log(this.data.likes);
+      if (!this.userStore.isLogined) {
+        alert("로그인이 필요한 서비스입니다.");
+        this.$router.push("/auth/login");
+        return;
+      }
+      if (await this.userStore.like(this.request)) {
+        this.isActive = !this.isActive;
+        this.heartIcon = this.isActive ? heartIconActive : heartIcon;
+      } else {
+        alert("관심 등록에 실패했습니다.");
+      }
+    },
   },
 };
 </script>

--- a/frontend/src/components/mainpage/ProductBoardListCardComponent.vue
+++ b/frontend/src/components/mainpage/ProductBoardListCardComponent.vue
@@ -77,6 +77,7 @@ export default {
     ...mapStores(useUserStore),
   },
   created() {
+    this.isLiked = this.data.likes;
     this.discountPrice = this.getDiscountPrice();
     this.calculatePercentage(); // 초기 퍼센트 계산
     setInterval(() => {

--- a/frontend/src/components/mainpage/ProductBoardListComponent.vue
+++ b/frontend/src/components/mainpage/ProductBoardListComponent.vue
@@ -26,8 +26,8 @@
     <div class="css-uh04a1 e19n19480">
       <ul class="css-6q2h7w e19n19481">
         <ProductBoardListCardComponent
-          v-for="(data, index) in dataList"
-          :key="index"
+          v-for="data in dataList"
+          :key="data.idx"
           :data="data"
         ></ProductBoardListCardComponent>
       </ul>

--- a/frontend/src/components/mypage/MypageLikesEventComponent.vue
+++ b/frontend/src/components/mypage/MypageLikesEventComponent.vue
@@ -187,8 +187,15 @@ export default {
   created() {
     this.getDataList();
   },
+  watch: {
+    // page가 변경되면 getDataList 호출
+    "$route.query.page"() {
+      this.getDataList();
+    },
+  },
   methods: {
     async getDataList() {
+      console.log(this.currentPage);
       const response = await this.boardStore.getLikesList(this.currentPage);
       if (response.totalPages > 0) {
         this.totalPages = response.totalPages;

--- a/frontend/src/components/mypage/MypageLikesEventComponent.vue
+++ b/frontend/src/components/mypage/MypageLikesEventComponent.vue
@@ -87,7 +87,7 @@
                     <div class="css-2qdoqn e19er7v40">
                       <button
                         class="css-17giheb e4nu7ef3"
-                        @click="removeItem(index)"
+                        @click="removeItem(data.idx)"
                       >
                         <span class="css-nytqmg e4nu7ef1">삭제</span>
                       </button>
@@ -147,6 +147,7 @@
 
 <script>
 import { useBoardStore } from "@/stores/useBoardStore";
+import { useUserStore } from "@/stores/useUserStore";
 import { mapStores } from "pinia";
 export default {
   data() {
@@ -156,6 +157,9 @@ export default {
       pages: [],
       pagesPerGroup: 5,
       totalElements: 0,
+      request: {
+        productBoardIdx: null,
+      },
     };
   },
   computed: {
@@ -183,6 +187,7 @@ export default {
       return pageNumbers;
     },
     ...mapStores(useBoardStore),
+    ...mapStores(useUserStore),
   },
   created() {
     this.getDataList();
@@ -231,6 +236,21 @@ export default {
     },
     removeItem(index) {
       this.dataList.splice(index, 1);
+      this.toggleHeart(index);
+    },
+    async toggleHeart(index) {
+      this.request.productBoardIdx = index;
+      if (!this.userStore.isLogined) {
+        alert("로그인이 필요한 서비스입니다.");
+        this.$router.push("/auth/login");
+        return;
+      }
+      if (await this.userStore.like(this.request)) {
+        alert("관심 등록을 취소했습니다.");
+      } else {
+        alert("실패했습니다.");
+      }
+      window.location.reload();
     },
   },
   mounted() {

--- a/frontend/src/pages/user/board/BoardDetailPage.vue
+++ b/frontend/src/pages/user/board/BoardDetailPage.vue
@@ -7,6 +7,7 @@
           <BoardDetailThumnailComponent :thumbnails="thumbnails" />
           <BoardDetailProductInfoComponent
             :data="data"
+            :productBoardIdx="productBoardIdx"
             @submitOrder="submitOrder"
           />
         </main>

--- a/frontend/src/stores/useBoardStore.js
+++ b/frontend/src/stores/useBoardStore.js
@@ -17,16 +17,19 @@ export const useBoardStore = defineStore("board", {
   }),
   actions: {
     async getMainList(page, status) {
+      const tokenExists = await this.checkToken();
       const response = await axios.get(backend + "/main/list", {
         params: {
           page: page,
           status: status,
         },
+        withCredentials: tokenExists,
       });
       console.log(response);
       return response.data.result;
     },
     async getList(page, category, search) {
+      const tokenExists = await this.checkToken();
       const params = { page: page };
       if (category != "undefined" && category != "null" && category != "전체") {
         params.search = category;
@@ -35,11 +38,16 @@ export const useBoardStore = defineStore("board", {
       }
       const response = await axios.get(backend + "/list", {
         params: params,
+        withCredentials: tokenExists,
       });
+      console.log(response);
       return response.data.result;
     },
     async getDetail(idx) {
-      const data = await axios.get(backend + `/${idx}/detail`);
+      const tokenExists = await this.checkToken();
+      const data = await axios.get(backend + `/${idx}/detail`, {
+        withCredentials: tokenExists,
+      });
       this.boardData = data.data.result;
       return data.data.result;
     },
@@ -52,6 +60,18 @@ export const useBoardStore = defineStore("board", {
       });
       console.log(response);
       return response.data.result;
+    },
+
+    async checkToken() {
+      try {
+        const response = await axios.get("/api/check-token", {
+          withCredentials: true,
+        });
+        return response.data.isValid; // 서버에서 쿠키 유효성 검사 결과 반환
+      } catch (error) {
+        console.error(error);
+        return false; // 오류가 발생하면 false 반환
+      }
     },
 
     // --------- 판매자 ---------


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #249 

<br>
 

## 📝 작업 내용

> 관심 게시글 표시 유지 기능 구현

<br>

## **💬 리뷰 요구사항(선택)**

>` backend/feature/likes/list` 브랜치와 함께 테스트 해주세요!
- 로그인한 상태에서 메인페이지(`/`)에 접속해서 관심버튼 누르고 다른 페이지 이동 or 새로고침했을 때 관심버튼이 유지되는지 확인
- 마이페이지(`/mypage/likes`)에 접속했을 때 지금까지 누른 관심 게시글 목록이 잘 뜨는지 확인
- 로그아웃 버튼을 눌러 로그아웃을 했을 때, 모두 빈 하트로 바뀌는지 확인
