### PR TITLE
[#222] 주문 기능 수정

### DIFF
--- a/backend/src/main/java/org/example/backend/domain/orders/model/dto/OrderedProductDto.java
+++ b/backend/src/main/java/org/example/backend/domain/orders/model/dto/OrderedProductDto.java
@@ -21,11 +21,8 @@ public class OrderedProductDto {
         @Schema(description = "주문한 수량", example = "3")
         private Integer quantity;
         public static OrderedProduct toEntity(Request request, Orders order) {
-
-            Product product = Product.builder().idx(request.getIdx()).build();
-
             return OrderedProduct.builder()
-                    .product(product)
+                    .productIdx(request.getIdx())
                     .quantity(request.quantity)
                     .orders(order)
                     .build();

--- a/backend/src/main/java/org/example/backend/domain/orders/model/entity/OrderedProduct.java
+++ b/backend/src/main/java/org/example/backend/domain/orders/model/entity/OrderedProduct.java
@@ -32,11 +32,9 @@ public class OrderedProduct {
     @JoinColumn(name="orders_idx")
     private Orders orders;
 
-    @ManyToOne
-    @JoinColumn(name="product_idx")
-    private Product product;
+    private Long productIdx;
 
-    public OrderedProductResponse toOrderedProductResponse(Integer discountRate) {
+    public OrderedProductResponse toOrderedProductResponse(Product product, Integer discountRate) {
         return OrderedProductResponse.builder()
                 .name(product.getName())
                 .amount(quantity)

--- a/backend/src/main/java/org/example/backend/domain/orders/service/OrderService.java
+++ b/backend/src/main/java/org/example/backend/domain/orders/service/OrderService.java
@@ -156,7 +156,7 @@ public class OrderService {
         List<OrderedProduct> orderedProducts = order.getOrderedProducts();
 
         orderedProducts.forEach((orderedProduct) -> {
-            Product product = productRepository.findByIdWithLock(orderedProduct.getProduct().getIdx())
+            Product product = productRepository.findByIdWithLock(orderedProduct.getProductIdx())
                     .orElseThrow(() -> new InvalidCustomException(ORDER_FAIL_PRODUCT_NOT_FOUND));
             product.increaseStock(orderedProduct.getQuantity());
 
@@ -186,8 +186,10 @@ public class OrderService {
         }
 
         List<OrderedProduct> orederdProducts = order.getOrderedProducts();
-        List<OrderedProductResponse> products = orederdProducts.stream().map(orderdProduct ->
-           orderdProduct.toOrderedProductResponse(board.getDiscountRate())
+        List<OrderedProductResponse> products = orederdProducts.stream().map(orderdProduct ->{
+            Product product = productRepository.findById(orderdProduct.getProductIdx()).orElseThrow();
+            return orderdProduct.toOrderedProductResponse(product, board.getDiscountRate());
+        }
         ).collect(Collectors.toList());
 
         return order.toCompanyOrderDetailResponse(products);

--- a/backend/src/main/java/org/example/backend/domain/orders/service/PaymentService.java
+++ b/backend/src/main/java/org/example/backend/domain/orders/service/PaymentService.java
@@ -24,7 +24,6 @@ import org.example.backend.domain.orders.model.entity.OrderedProduct;
 import org.example.backend.domain.orders.model.entity.Orders;
 import org.example.backend.global.exception.InvalidCustomException;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
@@ -33,7 +32,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class PaymentService {
     private final IamportClient iamportClient;
     private final ProductRepository productRepository;
-    private final EntityManager entityManager;
 
     public Payment getPaymentInfo(String impUid) throws IamportResponseException, IOException {
         IamportResponse<Payment> iamportResponse = iamportClient.paymentByImpUid(impUid);
@@ -72,11 +70,9 @@ public class PaymentService {
 
         List<OrderedProduct> orderedProducts = order.getOrderedProducts();
         orderedProducts.forEach((orderdProduct) -> {
-            Product product = productRepository.findByIdWithLock(orderdProduct.getProduct().getIdx())
+            Product product = productRepository.findByIdWithLock(orderdProduct.getProductIdx())
                         .orElseThrow(
                                 () -> new InvalidCustomException(ORDER_FAIL_PRODUCT_NOT_FOUND)); // 해당하는 상품을 찾을 수가 없을 때
-
-            entityManager.refresh(product); // 강제로 DB에서 최신 데이터를 읽어옴
 
             if (orderdProduct.getQuantity() > product.getStock()) {
                 refund(payment.getImpUid(), payment);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #222 

<br>
 

## 📝 작업 내용

> 주문 상품(ordered prodct)과 상품(product)의 연관관계를 양방향에서 단방향으로 수정했습니다.
-  ordered Product에서 product를 조회할 때(N:1 관계에 있는 엔티티를 조회), 비관적 락 없이 product를 가져오는 문제 발생
    - `orderedProduct.getProduct().getIdx()`
- 비관적 락이 걸리기 전에, 이미 1차 캐시에 product가 존재하게 되어서, DB의 최신 상태를 반영하지 못함
- ordered product에 `private Long productIdx` 를 추가함으로써, 연관관계 제거

<br>

## **💬 리뷰 요구사항(선택)**

- `frontend-dev` 브랜치와 함께 동작했을 때, 주문 기능이 제대로 동작하는지 확인해주세요!
