### PR TITLE
[#254] 게시글 조회 N + 1 문제 해결

### DIFF
--- a/backend/src/main/java/org/example/backend/domain/board/controller/BoardController.java
+++ b/backend/src/main/java/org/example/backend/domain/board/controller/BoardController.java
@@ -49,7 +49,8 @@ public class BoardController {
 		Pageable pageable = getPageableByStatus(status, page);
 		if (customUserDetails == null) {
 			responses = productBoardService.mainList(status, pageable);
-		} else {
+		 }
+		else {
 			responses = productBoardService.mainList(customUserDetails.getIdx(), status, pageable);
 		}
 		return new BaseResponse(responses);

--- a/backend/src/main/java/org/example/backend/domain/board/model/entity/ProductBoard.java
+++ b/backend/src/main/java/org/example/backend/domain/board/model/entity/ProductBoard.java
@@ -108,19 +108,19 @@ public class ProductBoard {
 			.build();
 	}
 
-	public ProductBoardDto.BoardDetailResponse toBoardDetailResponse(List<String> productThumbnailUrls, List<ProductDto.Response> products) {
+	public static ProductBoardDto.BoardDetailResponse toBoardDetailResponse(ProductBoard productBoard, List<String> productThumbnailUrls, List<ProductDto.Response> products) {
 		return ProductBoardDto.BoardDetailResponse.builder()
 			.productThumbnailUrls(productThumbnailUrls)
-			.productDetailUrl(this.productDetailUrl)
-			.title(this.title)
+			.productDetailUrl(productBoard.productDetailUrl)
+			.title(productBoard.title)
 			.products(products)
-			.startedAt(this.startedAt.withSecond(0).withNano(0))
-			.endedAt(this.endedAt.withNano(0).withNano(0))
-			.companyName(this.company.getCompanyName())
-			.category(this.category.getName())
+			.startedAt(productBoard.startedAt.withSecond(0).withNano(0))
+			.endedAt(productBoard.endedAt.withNano(0).withNano(0))
+			.companyName(productBoard.company.getCompanyName())
+			.category(productBoard.category.getName())
 			.likes(false)
 			.price(products.stream().min(Comparator.comparing(ProductDto.Response::getPrice)).map(ProductDto.Response::getPrice).orElse(null))
-			.discountRate(this.discountRate)
+			.discountRate(productBoard.discountRate)
 			.build();
 	}
 

--- a/backend/src/main/java/org/example/backend/domain/board/model/entity/ProductBoard.java
+++ b/backend/src/main/java/org/example/backend/domain/board/model/entity/ProductBoard.java
@@ -79,30 +79,31 @@ public class ProductBoard {
 	/* TODO
 	likes 부분 일단 false로 처리하고 추후 로그인 되어 있는 사용자일 경우 조회해서 값 세팅하도록 변경
 	* */
-	public ProductBoardDto.BoardListResponse toBoardListResponse() {
+	public static ProductBoardDto.BoardListResponse toBoardListResponse(ProductBoard productBoard) {
+
 		return ProductBoardDto.BoardListResponse.builder()
-			.idx(this.idx)
-			.productThumbnailUrl(this.productThumbnailUrl)
-			.title(this.title)
-			.companyName(this.company.getCompanyName())
-			.startedAt(this.startedAt.withSecond(0).withNano(0))
-			.endedAt(this.endedAt.withSecond(0).withNano(0))
-			.price(this.products.stream().min(Comparator.comparing(Product::getPrice)).map(Product::getPrice).orElse(null))
-			.discountRate(this.discountRate)
+			.idx(productBoard.idx)
+			.productThumbnailUrl(productBoard.productThumbnailUrl)
+			.title(productBoard.title)
+			.companyName(productBoard.company.getCompanyName())
+			.startedAt(productBoard.startedAt.withSecond(0).withNano(0))
+			.endedAt(productBoard.endedAt.withSecond(0).withNano(0))
+			.price(productBoard.products.stream().min(Comparator.comparing(Product::getPrice)).map(Product::getPrice).orElse(null))
+			.discountRate(productBoard.discountRate)
 			.likes(false)
 			.build();
 	}
 
-	public ProductBoardDto.BoardListResponse toBoardListResponse(Boolean isLiked) {
+	public static ProductBoardDto.BoardListResponse toBoardListResponse(ProductBoard productBoard, Boolean isLiked) {
 		return ProductBoardDto.BoardListResponse.builder()
-			.idx(this.idx)
-			.productThumbnailUrl(this.productThumbnailUrl)
-			.title(this.title)
-			.companyName(this.company.getCompanyName())
-			.startedAt(this.startedAt.withSecond(0).withNano(0))
-			.endedAt(this.endedAt.withSecond(0).withNano(0))
-			.price(this.products.stream().min(Comparator.comparing(Product::getPrice)).map(Product::getPrice).orElse(null))
-			.discountRate(this.discountRate)
+			.idx(productBoard.idx)
+			.productThumbnailUrl(productBoard.productThumbnailUrl)
+			.title(productBoard.title)
+			.companyName(productBoard.company.getCompanyName())
+			.startedAt(productBoard.startedAt.withSecond(0).withNano(0))
+			.endedAt(productBoard.endedAt.withSecond(0).withNano(0))
+			.price(productBoard.products.stream().min(Comparator.comparing(Product::getPrice)).map(Product::getPrice).orElse(null))
+			.discountRate(productBoard.discountRate)
 			.likes(isLiked)
 			.build();
 	}

--- a/backend/src/main/java/org/example/backend/domain/board/model/entity/ProductBoard.java
+++ b/backend/src/main/java/org/example/backend/domain/board/model/entity/ProductBoard.java
@@ -142,15 +142,15 @@ public class ProductBoard {
 
 
 	// 판매자 게시글 목록 조회 DTO
-	public ProductBoardDto.CompanyBoardListResponse toCompanyBoardListResponse() {
+	public static ProductBoardDto.CompanyBoardListResponse toCompanyBoardListResponse(ProductBoard productBoard) {
 		return ProductBoardDto.CompanyBoardListResponse.builder()
-			.idx(this.idx)
-			.productThumbnailUrl(this.productThumbnailUrl)
-			.title(this.title)
-			.category(this.category.getName())
-			.status(this.status) // <- 이부분 수정해야됨
-			.startedAt(this.startedAt)
-			.endedAt(this.endedAt)
+			.idx(productBoard.idx)
+			.productThumbnailUrl(productBoard.productThumbnailUrl)
+			.title(productBoard.title)
+			.category(productBoard.category.getName())
+			.status(productBoard.status) // <- 이부분 수정해야됨
+			.startedAt(productBoard.startedAt)
+			.endedAt(productBoard.endedAt)
 			.build();
 	}
 

--- a/backend/src/main/java/org/example/backend/domain/board/repository/ProductBoardRepository.java
+++ b/backend/src/main/java/org/example/backend/domain/board/repository/ProductBoardRepository.java
@@ -16,6 +16,6 @@ public interface ProductBoardRepository extends JpaRepository<ProductBoard, Long
 
 	List<ProductBoard> findByCompanyEmail(String companyEmail);
 
-	@Query("SELECT pb FROM ProductBoard pb JOIN FETCH pb.category WHERE pb.idx = :idx and pb.company.idx = :companyIdx")
+	@Query("SELECT pb FROM ProductBoard pb JOIN FETCH pb.category JOIN FETCH pb.productThumbnailImages WHERE pb.idx = :idx and pb.company.idx = :companyIdx")
 	Optional<ProductBoard> findByCompanyIdxAndIdx(Long companyIdx, Long idx);
 }

--- a/backend/src/main/java/org/example/backend/domain/board/repository/ProductBoardRepository.java
+++ b/backend/src/main/java/org/example/backend/domain/board/repository/ProductBoardRepository.java
@@ -18,6 +18,4 @@ public interface ProductBoardRepository extends JpaRepository<ProductBoard, Long
 
 	@Query("SELECT pb FROM ProductBoard pb JOIN FETCH pb.category WHERE pb.idx = :idx and pb.company.idx = :companyIdx")
 	Optional<ProductBoard> findByCompanyIdxAndIdx(Long companyIdx, Long idx);
-
-	Slice<ProductBoard> findByStatus(String status, Pageable pageable);
 }

--- a/backend/src/main/java/org/example/backend/domain/board/repository/ProductBoardRepository.java
+++ b/backend/src/main/java/org/example/backend/domain/board/repository/ProductBoardRepository.java
@@ -11,7 +11,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 public interface ProductBoardRepository extends JpaRepository<ProductBoard, Long>, ProductBoardRepositoryCustom {
-	@Query("SELECT pb FROM ProductBoard pb JOIN FETCH pb.category JOIN FETCH pb.company WHERE pb.idx = :idx")
+	@Query("SELECT pb FROM ProductBoard pb JOIN FETCH pb.category JOIN FETCH pb.company JOIN FETCH pb.productThumbnailImages WHERE pb.idx = :idx")
 	Optional<ProductBoard> findByIdx(Long idx);
 
 	List<ProductBoard> findByCompanyEmail(String companyEmail);

--- a/backend/src/main/java/org/example/backend/domain/board/repository/querydsl/ProductBoardRepositoryCustom.java
+++ b/backend/src/main/java/org/example/backend/domain/board/repository/querydsl/ProductBoardRepositoryCustom.java
@@ -3,8 +3,10 @@ package org.example.backend.domain.board.repository.querydsl;
 import org.example.backend.domain.board.model.entity.ProductBoard;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 public interface ProductBoardRepositoryCustom {
 	Page<ProductBoard> search(String search, Pageable pageable);
 	Page<ProductBoard> companySearch(Long companyIdx, String status, Integer month, Pageable pageable);
+	Slice<ProductBoard> searchByStatus(String status, Pageable pageable);
 }

--- a/backend/src/main/java/org/example/backend/domain/board/repository/querydsl/ProductBoardRepositoryCustomImpl.java
+++ b/backend/src/main/java/org/example/backend/domain/board/repository/querydsl/ProductBoardRepositoryCustomImpl.java
@@ -47,14 +47,22 @@ public class ProductBoardRepositoryCustomImpl implements ProductBoardRepositoryC
 			.selectFrom(qProductBoard)
 			.leftJoin(qProductBoard.category, qCategory).fetchJoin()
 			.leftJoin(qProductBoard.company, qCompany).fetchJoin()
+			.leftJoin(qProductBoard.products, qProduct).fetchJoin()
 			.where(getCondition(search));
-		int count = query.fetch().size();
+
+		JPQLQuery<Long> countQuery = queryFactory
+			.select(qProductBoard.count())
+			.from(qProductBoard)
+			.where(getCondition(search));
 
 		List<ProductBoard> result = query
 			.orderBy(qProductBoard.idx.desc())
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize())
 			.fetch();
+
+		long count = countQuery.fetch().size();
+
 		return new PageImpl<>(result, pageable, count);
 	}
 

--- a/backend/src/main/java/org/example/backend/domain/board/service/ProductBoardService.java
+++ b/backend/src/main/java/org/example/backend/domain/board/service/ProductBoardService.java
@@ -81,7 +81,7 @@ public class ProductBoardService {
 
 	public ProductBoardDto.BoardDetailResponse detail(Long idx) {
 		ProductBoard productBoard = productBoardRepository.findByIdx(idx).orElseThrow(() -> new InvalidCustomException(BaseResponseStatus.PRODUCT_BOARD_DETAIL_FAIL));
-		List<ProductThumbnailImage> productThumbnailImages = productThumbnailImageRepository.findAllByProductBoardIdx(idx).orElseThrow(() -> new InvalidCustomException(BaseResponseStatus.PRODUCT_BOARD_DETAIL_FAIL));
+		List<ProductThumbnailImage> productThumbnailImages = productBoard.getProductThumbnailImages();
 		List<Product> products = productRepository.findAllByProductBoardIdx(idx).orElseThrow(() -> new InvalidCustomException(BaseResponseStatus.PRODUCT_BOARD_DETAIL_FAIL));
 
 
@@ -91,12 +91,12 @@ public class ProductBoardService {
 		List<ProductDto.Response> productResponse = products.stream()
 			.map(Product::toResponse)
 			.toList();
-		return productBoard.toBoardDetailResponse(productThumbnailUrls, productResponse);
+		return ProductBoard.toBoardDetailResponse(productBoard, productThumbnailUrls, productResponse);
 	}
 
 	public ProductBoardDto.BoardDetailResponse detail(Long userIdx, Long idx) {
 		ProductBoard productBoard = productBoardRepository.findByIdx(idx).orElseThrow(() -> new InvalidCustomException(BaseResponseStatus.PRODUCT_BOARD_DETAIL_FAIL));
-		List<ProductThumbnailImage> productThumbnailImages = productThumbnailImageRepository.findAllByProductBoardIdx(idx).orElseThrow(() -> new InvalidCustomException(BaseResponseStatus.PRODUCT_BOARD_DETAIL_FAIL));
+		List<ProductThumbnailImage> productThumbnailImages = productBoard.getProductThumbnailImages();
 		List<Product> products = productRepository.findAllByProductBoardIdx(idx).orElseThrow(() -> new InvalidCustomException(BaseResponseStatus.PRODUCT_BOARD_DETAIL_FAIL));
 
 

--- a/backend/src/main/java/org/example/backend/domain/board/service/ProductBoardService.java
+++ b/backend/src/main/java/org/example/backend/domain/board/service/ProductBoardService.java
@@ -128,7 +128,7 @@ public class ProductBoardService {
 
 	public ProductBoardDto.CompanyBoardDetailResponse getCompanyDetail(Long companyIdx, Long idx) {
 		ProductBoard productBoard = productBoardRepository.findByCompanyIdxAndIdx(companyIdx, idx).orElseThrow(() -> new InvalidCustomException(BaseResponseStatus.PRODUCT_BOARD_DETAIL_FAIL));
-		List<ProductThumbnailImage> productThumbnailImages = productThumbnailImageRepository.findAllByProductBoardIdx(idx).orElseThrow(() -> new InvalidCustomException(BaseResponseStatus.PRODUCT_BOARD_DETAIL_FAIL));
+		List<ProductThumbnailImage> productThumbnailImages = productBoard.getProductThumbnailImages();
 		List<Product> products = productRepository.findAllByProductBoardIdx(idx).orElseThrow(() -> new InvalidCustomException(BaseResponseStatus.PRODUCT_BOARD_DETAIL_FAIL));
 
 		List<String> productThumbnailUrls = productThumbnailImages.stream()

--- a/backend/src/main/java/org/example/backend/domain/board/service/ProductBoardService.java
+++ b/backend/src/main/java/org/example/backend/domain/board/service/ProductBoardService.java
@@ -3,6 +3,7 @@ package org.example.backend.domain.board.service;
 import java.io.IOException;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -28,6 +29,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -52,15 +54,15 @@ public class ProductBoardService {
 	private String bucket;
 
 	public Slice<ProductBoardDto.BoardListResponse> mainList(String status, Pageable pageable) {
-		Slice<ProductBoard> productBoards = productBoardRepository.findByStatus(BoardStatus.from(status).getStatus(), pageable);
+		Slice<ProductBoard> productBoards = productBoardRepository.searchByStatus(BoardStatus.from(status).getStatus(), pageable);
 		return productBoards.map(ProductBoard::toBoardListResponse);
 	}
 
 	public Slice<ProductBoardDto.BoardListResponse> mainList(Long userIdx, String status, Pageable pageable) {
-		Slice<ProductBoard> productBoards = productBoardRepository.findByStatus(BoardStatus.from(status).getStatus(), pageable);
+		Slice<ProductBoard> productBoards = productBoardRepository.searchByStatus(BoardStatus.from(status).getStatus(), pageable);
 		return productBoards.map(productBoard -> {
-			boolean isLiked = likesRepository.findByUserIdxAndProductBoardIdx(userIdx, productBoard.getIdx()).isPresent();
-			return productBoard.toBoardListResponse(isLiked);
+			boolean isLiked = likesRepository.existsByProductBoardIdxAndUserIdx(userIdx, productBoard.getIdx());
+			return ProductBoard.toBoardListResponse(productBoard, isLiked);
 		});
 	}
 
@@ -72,8 +74,8 @@ public class ProductBoardService {
 	public Page<ProductBoardDto.BoardListResponse> list(Long userIdx, String search, Pageable pageable) {
 		Page<ProductBoard> productBoards = productBoardRepository.search(search, pageable);
 		return productBoards.map(productBoard -> {
-			boolean isLiked = likesRepository.findByUserIdxAndProductBoardIdx(userIdx, productBoard.getIdx()).isPresent();
-			return productBoard.toBoardListResponse(isLiked);
+			boolean isLiked = likesRepository.existsByProductBoardIdxAndUserIdx(userIdx, productBoard.getIdx());
+			return ProductBoard.toBoardListResponse(productBoard, isLiked);
 		});
 	}
 
@@ -104,7 +106,7 @@ public class ProductBoardService {
 		List<ProductDto.Response> productResponse = products.stream()
 			.map(Product::toResponse)
 			.toList();
-		boolean isLiked = likesRepository.findByUserIdxAndProductBoardIdx(userIdx, productBoard.getIdx()).isPresent();
+		boolean isLiked = likesRepository.existsByProductBoardIdxAndUserIdx(userIdx, productBoard.getIdx());
 		return productBoard.toBoardDetailResponse(productThumbnailUrls, productResponse, isLiked);
 	}
 

--- a/backend/src/main/java/org/example/backend/domain/likes/repository/LikesRepository.java
+++ b/backend/src/main/java/org/example/backend/domain/likes/repository/LikesRepository.java
@@ -21,5 +21,5 @@ public interface LikesRepository extends JpaRepository<Likes, Long> {
     @Query("SELECT l FROM Likes l JOIN FETCH l.productBoard WHERE l.user.idx = :userIdx")
     Page<Likes> findAllByUserIdx(@Param("userIdx") Long userIdx, Pageable pageable);
 
-    Optional<Likes> findByUserIdxAndProductBoardIdx(Long userIdx, Long productBoardIdx);
+    Boolean existsByProductBoardIdxAndUserIdx(Long productBoardIdx, Long userIdx);
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #254 

<br>
 

## 📝 작업 내용

> 게시글 조회 N + 1 문제 해결
- 메인 리스트 게시글 조회 - `Slice`
  - **쿼리DSL + 페치 조인 적용**
  - [로그인 X] 쿼리 수: **6**  ➡️ **1**
  - [로그인 O] 쿼리 수: **7** ➡️ **1 + 1(좋아요 여부)**
- 검색어에 따른 게시글 조회 - `Page`
  - **쿼리DSL + 페치 조인 적용**
  - [로그인 X] 쿼리 수: **1 + 1(카운트 쿼리)**
  - [로그인 O] 쿼리 수: **1 + 1(카운트 쿼리) + 1(좋아요 여부)**
- 게시글 상세 조회
  - [로그인 X] 쿼리 수: **1 + 1(상품 쿼리)**
  - [로그인 O] 쿼리 수: **1 + 1(상품 쿼리) + 1(좋아요 여부)**
- 판매자 게시글 조회 - `Page`
  - **쿼리 수: 1 + 1(카운트 쿼리)**
- 판매자 게시글 상세 조회
  - **쿼리 수: 1 + 1(상품 쿼리)**

<br>

## **💬 리뷰 요구사항(선택)**

> 
