### PR TITLE
[#276] 문의 관련 페이징처리 API연동 수정

### DIFF
--- a/frontend/src/components/board/BoardDetailNavComponent.vue
+++ b/frontend/src/components/board/BoardDetailNavComponent.vue
@@ -115,14 +115,14 @@
       </table>
       <div class="css-rdz8z7 e82lnfz1" v-if="totalInquiries > 0">
         <!-- 처음 페이지로 이동 -->
-          <a class="page-unselected" @click="goToPage(1)">
+          <a class="page-unselected" @click="goToFirstPage">
             <img
               src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAkAAAAHCAQAAABwkq/rAAAAHUlEQVR42mNgAIPi/8X/kWkwA8SE0UQIMJAsCKMBBzk27fqtkcYAAAAASUVORK5CYII="
               alt="처음 페이지로 이동"
             />
           </a>
           <!-- 이전 페이지로 이동 -->
-          <a class="page-unselected" @click="prevPageGroup">
+          <a class="page-unselected" @click="prevPage">
             <img
               src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAHCAQAAABqrk9lAAAAGElEQVR42mNgAIPi/8X/4QwwE5PBQJADAAKSG3cyVhtXAAAAAElFTkSuQmCC"
               alt="이전 페이지로 이동"/>
@@ -138,13 +138,13 @@
             {{ pageNumber }}
           </a>
           <!-- 다음 페이지로 이동 -->
-          <a class="page-unselected" @click="nextPageGroup">
+          <a class="page-unselected" @click="nextPage">
             <img
             src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAHCAQAAABqrk9lAAAAGUlEQVR42mMo/l/8nwECQEwCHEwGhAlRBgA2mht3SwgzrwAAAABJRU5ErkJggg=="
             alt="다음 페이지로 이동"/>
           </a>
           <!-- 마지막 페이지로 이동 -->
-          <a class="page-unselected" @click="goToPage(totalPages)">
+          <a class="page-unselected" @click="goToLastPage">
             <img
               src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAkAAAAHCAQAAABwkq/rAAAAIElEQVR42mMo/l/8n4GBgQFGQ5kgDowmQZCwAMImhDkAb0k27Zcisn8AAAAASUVORK5CYII="
               alt="마지막 페이지로 이동"/>
@@ -239,7 +239,7 @@ export default {
       expandedInquiryIndex: null,
       editingIndex: null,
       currentPage: 1,
-      pageSize: 6,
+      pageSize: 5,
       totalInquiries: 0,
       pagesPerGroup: 5,
       // 사용자 정보를 직접 관리하기 위해 새로운 상태 추가
@@ -355,17 +355,21 @@ export default {
         this.loadInquiries();
       }
     },
-    prevPageGroup() {
-      const newPage = this.startPage - 1;
-      if (newPage >= 1) {
-        this.goToPage(newPage);
-      }
+    goToFirstPage(){
+      this.goToPage(1);
     },
-    nextPageGroup() {
-      const newPage = this.endPage + 1;
-      if (newPage <= this.totalPages){
-        this.goToPage(newPage);
-      }
+    goToLastPage(){
+      this.goToPage(this.totalPages);
+    },
+    prevPage() {
+        if (this.currentPage > 1) {
+            this.goToPage(this.currentPage - 1); // 현재 페이지의 이전 페이지로 이동
+        }
+    },
+    nextPage() {
+        if (this.currentPage < this.totalPages) {
+            this.goToPage(this.currentPage + 1); // 현재 페이지의 다음 페이지로 이동
+        }
     },
     // 새로운 사용자 정보 로드 메서드 추가
     async getUserDetailWithoutAlert() {

--- a/frontend/src/stores/useQnaStore.js
+++ b/frontend/src/stores/useQnaStore.js
@@ -3,14 +3,19 @@ import axios from "axios";
 
 export const useQnaStore = defineStore("qna", {
     state: () => ({
-        inquiries: []
+        inquiries: [],
+        totalInquiries: 0, // 총 문의 개수 관리
     }),
     actions: {
-        async fetchInquiries() {
+        async fetchInquiries(productBoardIdx, page = 1) {
             try {
-                const response = await axios.get('/api/qna/question/list');
+                const response = await axios.get(`/api/qna/question/list?productBoardIdx=${productBoardIdx}&page=${page}`);
                 if (response.data.isSuccess) {
-                    this.inquiries = response.data.result;
+                    this.inquiries = response.data.result.content;
+                    this.totalInquiries = response.data.result.totalElements;
+
+                    console.log(`현재 페이지: ${page}`);
+                    console.log("받아온 문의 목록:", this.inquiries);
                 } else {
                     console.error('문의 목록을 불러오는 중 오류 발생:', response.data.message);
                 }

--- a/frontend/src/stores/useQnaStore.js
+++ b/frontend/src/stores/useQnaStore.js
@@ -13,9 +13,6 @@ export const useQnaStore = defineStore("qna", {
                 if (response.data.isSuccess) {
                     this.inquiries = response.data.result.content;
                     this.totalInquiries = response.data.result.totalElements;
-
-                    console.log(`현재 페이지: ${page}`);
-                    console.log("받아온 문의 목록:", this.inquiries);
                 } else {
                     console.error('문의 목록을 불러오는 중 오류 발생:', response.data.message);
                 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #276

<br>
 

## 📝 작업 내용

> 백엔드에서 수정된 문의 조회 관련 API와 프론트엔드의 페이징 처리 로직을 연동
- 문의 관련 기능(문의탭, My 문의, 1:1 문의 관리)에서 백엔드 페이징 API 연동 완료
- 페이징 버튼 클릭 시 정확한 페이지 번호에 맞는 문의 목록을 불러오는 기능 추가
- 데이터 로드 시 발생했던 성능 이슈 개선 및 UI 표시 문제 해결

<br>

## **💬 리뷰 요구사항(선택)**

> `backend/fix/user/qna-paging` 브랜치와 함께
상품 게시글의 `문의 탭`, 마이페이지의 `My 문의`, `1:1 문의 관리` 페이지에서 테스트 부탁드립니다.
- 페이지 이동 시 데이터가 정확히 불러와지고, 페이징 버튼이 제대로 동작하는지 확인 부탁드립니다.
