### PR TITLE
[#278] 문의 관련 페이징처리 API 수정

### DIFF
--- a/backend/src/main/java/org/example/backend/domain/qna/controller/QuestionController.java
+++ b/backend/src/main/java/org/example/backend/domain/qna/controller/QuestionController.java
@@ -11,6 +11,10 @@ import org.example.backend.global.common.constants.BaseResponseStatus;
 import org.example.backend.global.common.constants.SwaggerDescription;
 import org.example.backend.global.common.constants.SwaggerExamples;
 import org.example.backend.global.exception.InvalidCustomException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
@@ -23,6 +27,7 @@ import java.util.List;
 public class QuestionController {
 
     private final QuestionService questionService;
+    private final int PAGE_SIZE = 5;
 
     @Operation(summary = "문의 등록 API", description = SwaggerDescription.QNA_QUESTION_REQUEST,
             requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
@@ -44,8 +49,9 @@ public class QuestionController {
 
     @Operation(summary = "문의 목록 조회 API", description = "DB에 저장된 문의 목록을 반환합니다.")
     @GetMapping("/list")
-    public BaseResponse<List<QuestionDto.QuestionListResponse>> getQuestions() {
-        List<QuestionDto.QuestionListResponse> questionList = questionService.getQuestions();
+    public BaseResponse<Page<QuestionDto.QuestionListResponse>> getQuestions(@RequestParam(value = "page", defaultValue = "1") int page, @RequestParam(value = "productBoardIdx") Long productBoardIdx) {
+        Pageable pageable = PageRequest.of(page - 1, PAGE_SIZE, Sort.by(Sort.Direction.DESC,"createdAt"));
+        Page<QuestionDto.QuestionListResponse> questionList = questionService.getQuestionsByProductBoardIdx(productBoardIdx, pageable);
         return new BaseResponse<>(questionList);
     }
 
@@ -56,19 +62,22 @@ public class QuestionController {
         return new BaseResponse<>(BaseResponseStatus.SUCCESS);
     }
 
-    @Operation(summary = "문의 목록 조회 API", description = "로그인된 기업 회원이 자신의 게시글에 달린 문의만 조회합니다.")
+    @Operation(summary = "기업 회원의 게시글에 달린 문의 목록 조회 API", description = "로그인된 기업 회원이 작성한 게시글에 달린 문의 목록을 조회합니다.")
     @GetMapping("/list/company")
-    public BaseResponse<List<QuestionDto.QuestionListResponse>> getCompanyQuestions(@AuthenticationPrincipal UserDetails userDetails) {
-        String companyEmail = userDetails.getUsername();  // 인증된 기업 회원의 이메일 가져오기
-        List<QuestionDto.QuestionListResponse> questionList = questionService.getQuestionsByCompanyEmail(companyEmail);
+    public BaseResponse<Page<QuestionDto.QuestionListResponse>> getCompanyBoardQuestions(@AuthenticationPrincipal UserDetails userDetails, @RequestParam(value = "page", defaultValue = "1") int page) {
+        String companyEmail = userDetails.getUsername();
+        Pageable pageable = PageRequest.of(page - 1, PAGE_SIZE, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<QuestionDto.QuestionListResponse> questionList = questionService.getQuestionsByCompanyBoard(companyEmail, pageable);
         return new BaseResponse<>(questionList);
     }
 
-    @Operation(summary = "로그인된 사용자의 문의 목록 조회 API", description = "로그인된 사용자가 작성한 문의 목록만 조회합니다.")
+
+    @Operation(summary = "사용자 문의 목록 조회 API", description = "로그인된 사용자가 작성한 문의 목록만 조회합니다.")
     @GetMapping("/list/my")
-    public BaseResponse<List<QuestionDto.QuestionListResponse>> getMyQuestions(@AuthenticationPrincipal UserDetails userDetails) {
-        String userEmail = userDetails.getUsername();  // 인증된 사용자의 이메일 가져오기
-        List<QuestionDto.QuestionListResponse> questionList = questionService.getQuestionsByUserEmail(userEmail);
+    public BaseResponse<Page<QuestionDto.QuestionListResponse>> getMyQuestions(@AuthenticationPrincipal UserDetails userDetails, @RequestParam(value = "page", defaultValue = "1") int page) {
+        String userEmail = userDetails.getUsername();
+        Pageable pageable = PageRequest.of(page - 1, PAGE_SIZE, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<QuestionDto.QuestionListResponse> questionList = questionService.getQuestionsByUserEmail(userEmail, pageable);
         return new BaseResponse<>(questionList);
     }
 

--- a/backend/src/main/java/org/example/backend/domain/qna/repository/QuestionRepository.java
+++ b/backend/src/main/java/org/example/backend/domain/qna/repository/QuestionRepository.java
@@ -3,11 +3,14 @@ package org.example.backend.domain.qna.repository;
 import org.example.backend.domain.board.model.entity.ProductBoard;
 import org.example.backend.domain.qna.model.entity.Question;
 import org.example.backend.domain.user.model.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface QuestionRepository extends JpaRepository<Question, Long> {
-    List<Question> findByProductBoardIn(List<ProductBoard> productBoards);
-    List<Question> findByUser(User user);
+    Page<Question> findByProductBoardIn(List<ProductBoard> productBoards, Pageable pageable);
+    Page<Question> findByUser(User user, Pageable pageable);
+    Page<Question> findByProductBoard_Idx(Long productBoardIdx, Pageable pageable);
 }

--- a/backend/src/main/java/org/example/backend/domain/qna/service/QuestionService.java
+++ b/backend/src/main/java/org/example/backend/domain/qna/service/QuestionService.java
@@ -14,6 +14,8 @@ import org.example.backend.domain.user.repository.UserRepository;
 import org.example.backend.global.common.constants.AnswerStatus;
 import org.example.backend.global.common.constants.BaseResponseStatus;
 import org.example.backend.global.exception.InvalidCustomException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -44,10 +46,8 @@ public class QuestionService {
         return question.toCreateResponse();  // 엔티티의 변환 메서드 사용
     }
 
-    public List<QuestionDto.QuestionListResponse> getQuestions() {
-        return questionRepository.findAll().stream()
-                .map(Question::toListResponse)  // 엔티티의 변환 메서드 사용
-                .collect(Collectors.toList());
+    public Page<QuestionDto.QuestionListResponse> getQuestionsByProductBoardIdx(Long productBoardIdx, Pageable pageable) {
+        return questionRepository.findByProductBoard_Idx(productBoardIdx, pageable).map(Question::toListResponse);
     }
 
     public void deleteQuestion(Long questionId, String email){
@@ -68,21 +68,11 @@ public class QuestionService {
         questionRepository.delete(question);
     }
 
-    public List<QuestionDto.QuestionListResponse> getQuestionsByCompanyEmail(String companyEmail) {
-        List<ProductBoard> productBoards = productBoardRepository.findByCompanyEmail(companyEmail);
-
-        return questionRepository.findByProductBoardIn(productBoards).stream()
-                .map(Question::toListResponse)  // 엔티티의 변환 메서드 사용
-                .collect(Collectors.toList());
-    }
-
-    public List<QuestionDto.QuestionListResponse> getQuestionsByUserEmail(String userEmail) {
+    public Page<QuestionDto.QuestionListResponse> getQuestionsByUserEmail(String userEmail, Pageable pageable) {
         User user = userRepository.findByEmail(userEmail)
                 .orElseThrow(() -> new InvalidCustomException(BaseResponseStatus.QNA_USER_NOT_FOUND));
-
-        return questionRepository.findByUser(user).stream()
-                .map(Question::toListResponse)  // 엔티티의 변환 메서드 사용
-                .collect(Collectors.toList());
+        return questionRepository.findByUser(user, pageable)
+                .map(Question::toListResponse);
     }
 
     public void updateQuestion(Long id, QuestionDto.QuestionUpdateRequest request, String email) {
@@ -98,5 +88,15 @@ public class QuestionService {
         // 문의 내용 업데이트
         question.updateContent(request.getTitle(), request.getContent());
         questionRepository.save(question);  // 수정된 문의 저장
+    }
+
+    public Page<QuestionDto.QuestionListResponse> getQuestionsByCompanyBoard(String companyEmail, Pageable pageable) {
+        List<ProductBoard> productBoards = productBoardRepository.findByCompanyEmail(companyEmail);
+        if (productBoards.isEmpty()) {
+            return Page.empty(pageable);
+        }
+
+        return questionRepository.findByProductBoardIn(productBoards, pageable)
+                .map(Question::toListResponse);
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #278

<br>
 

## 📝 작업 내용

> 문의 조회 관련 API의 페이징 처리 로직을 수정하여 성능과 데이터 일관성 문제를 해결
- 페이지 번호에 따른 문의 목록을 정확히 반환하도록 페이징 처리 로직 개선
- 불필요한 데이터 로드를 줄이고, 페이징 처리 시 발생하는 성능 문제 최적화
- `문의 탭`, `My 문의`, `1:1 문의 관리` 페이지와의 연동을 위한 API 개선
<br>

## **💬 리뷰 요구사항(선택)**

> `frontend/fix/user/qna-paging` 브랜치와 함께 테스트 부탁드립니다.
(요구사항은 #279 참고)
