### PR TITLE
[#328] MSA 문의 조회 N+1문제 해결

### DIFF
--- a/backend/board/src/main/java/org/example/board/domain/qna/repository/QuestionRepository.java
+++ b/backend/board/src/main/java/org/example/board/domain/qna/repository/QuestionRepository.java
@@ -6,11 +6,15 @@ import org.example.board.domain.user.model.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface QuestionRepository extends JpaRepository<Question, Long> {
-    Page<Question> findByProductBoardIn(List<ProductBoard> productBoards, Pageable pageable);
-    Page<Question> findByUser(User user, Pageable pageable);
+    @Query("SELECT q FROM Question q JOIN FETCH q.productBoard pb WHERE pb.idx=:productBoardIdx")
     Page<Question> findByProductBoard_Idx(Long productBoardIdx, Pageable pageable);
+
+    Page<Question> findByProductBoardIn(List<ProductBoard> productBoards, Pageable pageable);
+
+    Page<Question> findByUser(User user, Pageable pageable);
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #328

<br>
 

## 📝 작업 내용

> MSA 구조로 전환된 문의 조회 기능에서 발생한 N+1 문제를 해결했습니다.
- 페치 조인을 사용해 문의와 관련된 데이터를 한 번의 쿼리로 가져오도록 수정
- 성능 최적화를 위해 @BatchSize를 5로 설정해서 데이터 조회 시 배치 크기를 조절

<br>

## **💬 리뷰 요구사항(선택)**

> 불필요한 파일 체인지가 있는지 더블체크 부탁드립니다.
